### PR TITLE
ATV-2 | Add permission check for the ServiceAPIKey

### DIFF
--- a/atv/settings.py
+++ b/atv/settings.py
@@ -38,6 +38,7 @@ env = environ.Env(
     VERSION=(str, None),
     DJANGO_LOG_LEVEL=(str, "INFO"),
     CSRF_TRUSTED_ORIGINS=(list, []),
+    API_KEY_CUSTOM_HEADER=(str, "HTTP_X_API_KEY"),
 )
 if os.path.exists(env_file):
     env.read_env(env_file)
@@ -143,9 +144,18 @@ TEMPLATES = [
 CORS_ORIGIN_WHITELIST = env.list("CORS_ORIGIN_WHITELIST")
 CORS_ORIGIN_ALLOW_ALL = env.bool("CORS_ORIGIN_ALLOW_ALL")
 
+REST_FRAMEWORK = {
+    "DEFAULT_PERMISSION_CLASSES": [
+        "services.permissions.HasServiceAPIKey",
+    ]
+}
+
 # Authentication
 
 AUTH_USER_MODEL = "users.User"
+
+API_KEY_CUSTOM_HEADER = env("API_KEY_CUSTOM_HEADER")
+
 
 LOGGING = {
     "version": 1,

--- a/atv/urls.py
+++ b/atv/urls.py
@@ -1,9 +1,17 @@
 from django.contrib import admin
 from django.http import HttpResponse
-from django.urls import path
+from django.urls import include, path
+from rest_framework import routers
+
+from services.api import DocumentsViewSet
+
+router = routers.DefaultRouter()
+router.register(r"documents", DocumentsViewSet, basename="documents")
+
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("", include(router.urls)),
 ]
 
 

--- a/requirements.in
+++ b/requirements.in
@@ -2,8 +2,7 @@ Django~=3.2
 django-cors-headers
 django-environ
 django-filter
-# django-helusers, TODO use upstream when https://github.com/City-of-Helsinki/django-helusers/pull/55 is released
-git+https://github.com/City-of-Helsinki/django-helusers.git@f5c57241c50f970e38f17461591f6ac00a5fe0fe#egg=django-helusers
+django-helusers
 djangorestframework
 djangorestframework-api-key
 psycopg2

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ django-environ==0.4.5
     # via -r requirements.in
 django-filter==2.4.0
     # via -r requirements.in
-git+https://github.com/City-of-Helsinki/django-helusers.git@f5c57241c50f970e38f17461591f6ac00a5fe0fe#egg=django-helusers
+django-helusers==0.6.1
     # via -r requirements.in
 django==3.2.3
     # via

--- a/services/api.py
+++ b/services/api.py
@@ -1,0 +1,7 @@
+from rest_framework import status, viewsets
+from rest_framework.response import Response
+
+
+class DocumentsViewSet(viewsets.ViewSet):
+    def create(self, request):
+        return Response({"status": "CREATED"}, status=status.HTTP_201_CREATED)

--- a/services/permissions.py
+++ b/services/permissions.py
@@ -1,0 +1,7 @@
+from rest_framework_api_key.permissions import BaseHasAPIKey
+
+from .models import ServiceAPIKey
+
+
+class HasServiceAPIKey(BaseHasAPIKey):
+    model = ServiceAPIKey

--- a/services/tests/conftest.py
+++ b/services/tests/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 from pytest_factoryboy import register
+from rest_framework.test import APIClient
 
 from services.tests.factories import ServiceAPIKeyFactory, ServiceFactory
 
@@ -7,6 +8,11 @@ from services.tests.factories import ServiceAPIKeyFactory, ServiceFactory
 @pytest.fixture(autouse=True)
 def autouse_db(db):
     pass
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
 
 
 register(ServiceFactory)

--- a/services/tests/test_api_authentication.py
+++ b/services/tests/test_api_authentication.py
@@ -1,0 +1,37 @@
+from django.conf import settings
+from django.urls import reverse
+from rest_framework import status
+
+from ..models import ServiceAPIKey
+from .factories import ServiceFactory
+
+
+def get_api_key():
+    service = ServiceFactory()
+    api_key, key = ServiceAPIKey.objects.create_key(name="APIKey", service=service)
+    return key
+
+
+def test_anonymous_user_can_post_documents_api_with_a_correct_api_key(api_client):
+    key = get_api_key()
+
+    api_client.credentials(**{settings.API_KEY_CUSTOM_HEADER: key})
+    response = api_client.post(reverse("documents-list"), json={"data": "ok"})
+
+    assert response.status_code == status.HTTP_201_CREATED
+    assert response.json() == {"status": "CREATED"}
+
+
+def test_anonymous_user_cannot_post_documents_api_with_a_wrong_api_key(api_client):
+    key = get_api_key()
+
+    api_client.credentials(**{settings.API_KEY_CUSTOM_HEADER: key[::-1]})
+    response = api_client.post(reverse("documents-list"), json={"data": "ok"})
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_anonymous_user_cannot_post_documents_api_without_an_api_key(api_client):
+    response = api_client.post(reverse("documents-list"), json={"data": "ok"})
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN


### PR DESCRIPTION
This PR adds initial permission check for the `ServiceAPIKey` model.
- Adds `HasServiceAPIKey` permission class
- Initial dummy documents API
- Use `X-Api-Key` header for the API key