### PR TITLE
Fix building production image

### DIFF
--- a/atv/settings.py
+++ b/atv/settings.py
@@ -40,7 +40,7 @@ env = environ.Env(
     DJANGO_LOG_LEVEL=(str, "INFO"),
     CSRF_TRUSTED_ORIGINS=(list, []),
     API_KEY_CUSTOM_HEADER=(str, "HTTP_X_API_KEY"),
-    FIELD_ENCRYPTION_KEYS=(list, None),
+    FIELD_ENCRYPTION_KEYS=(list, []),
     ENABLE_AUTOMATIC_ATTACHMENT_FILE_DELETION=(bool, True),
 )
 if os.path.exists(env_file):


### PR DESCRIPTION
When building the production image `FIELD_ENCRYPTION_KEYS` is not available. This broke the build when static assets were being collected.

Refs ATV-1
