### PR TITLE
ATV-1 | Mount /srv/atv doesn't require permission trick in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,6 @@ COPY --chown=appuser:appuser . /app/
 # Need to set the permissions beforehand for the Attachment directory
 # https://github.com/docker/compose/issues/3270#issuecomment-363478501
 RUN mkdir -p /var/media/ && chown -R appuser:appuser /var/media/
-RUN mkdir -p /srv/atv/ && chown -R appuser:appuser /srv/atv/
 
 USER appuser
 
@@ -58,9 +57,7 @@ COPY --chown=appuser:appuser . /app/
 
 # Need to set the permissions beforehand for the Attachment directory
 # https://github.com/docker/compose/issues/3270#issuecomment-363478501
-# TODO: Figure out whether this is for production as well
 RUN mkdir -p /var/media/ && chown -R appuser:appuser /var/media/
-RUN mkdir -p /srv/atv/ && chown -R appuser:appuser /srv/atv/
 
 USER appuser
 


### PR DESCRIPTION
## Description :sparkles:

Mount point (in production) seems to have read+write+execute for all parties.

Also it looks like the file permissions in OpenShift env behave normally i.e. folder permissions (for /srv/atv) are replaced by the permissions from the mount, so the same Dockerfile trick doesn't work.

## Screenshots :camera_flash:

From production:
![Screenshot from 2021-08-16 10-11-34](https://user-images.githubusercontent.com/225211/129525131-6a52d5f1-16ed-4b1a-b1b6-8583b14deb1d.png)

