### PR TITLE
Validate that posted attachments are not None

### DIFF
--- a/documents/serializers/document.py
+++ b/documents/serializers/document.py
@@ -72,7 +72,7 @@ class CreateAnonymousDocumentSerializer(serializers.ModelSerializer):
 
         # Validate that no more than settings.MAX_FILE_UPLOAD_ALLOWED files
         # are uploaded on the same call
-        if len(attrs.get("attachments")) > settings.MAX_FILE_UPLOAD_ALLOWED:
+        if len(attrs.get("attachments", [])) > settings.MAX_FILE_UPLOAD_ALLOWED:
             raise ValidationError(
                 _("File upload is limited to {max_file_upload_allowed}").format(
                     max_file_upload_allowed=settings.MAX_FILE_UPLOAD_ALLOWED
@@ -82,7 +82,7 @@ class CreateAnonymousDocumentSerializer(serializers.ModelSerializer):
         return attrs
 
     def create(self, validated_data):
-        attachments = validated_data.pop("attachments")
+        attachments = validated_data.pop("attachments", [])
 
         document = Document.objects.create(**validated_data)
         for attached_file in attachments:

--- a/documents/tests/test_api_create_document.py
+++ b/documents/tests/test_api_create_document.py
@@ -119,3 +119,23 @@ def test_create_document_file_limit(service_api_client):
 
     body = response.json()
     assert body == {"errors": ["Cannot upload files larger than 20.0 MB"]}
+
+
+def test_create_document_no_attachments(service_api_client):
+    assert Document.objects.count() == 0
+    assert Attachment.objects.count() == 0
+
+    response = service_api_client.post(
+        reverse("documents-list"), VALID_DOCUMENT_DATA, format="multipart"
+    )
+
+    assert response.status_code == status.HTTP_201_CREATED
+    assert Document.objects.count() == 1
+    assert Attachment.objects.count() == 0
+
+    document = Document.objects.first()
+    assert document.attachments.count() == 0
+
+    body = response.json()
+
+    assert body.get("attachments") == []


### PR DESCRIPTION
## Description :sparkles:
When submitting a new document without file attachments, the serializer
tried to check for file limits and pop the data from the original
validated data. Because no files were uploaded, the value was None, and
it was failing the check for max uploads and later when popping them
from the data.

* Add checks so that the `attachment` field has a default value to avoid `None`s

## Issues :bug:
### Closes :no_good_woman:
**[ATV-54](https://helsinkisolutionoffice.atlassian.net/browse/ATV-54):** Fix Document attachment upload
Closes Sentry error [ATV-API-8](https://sentry.io/share/issue/c5a240c36b884cada5bb683b9ec7f0dd/)

## Testing :alembic:
### Automated tests :gear:️
```bash
pytest documents/tests/test_api_create_document.py::test_create_document_no_attachments
```

### Manual testing :construction_worker_man:
```bash
curl --location --request POST 'http://localhost:8000/v1/documents/' \
--header 'X-Api-Key: <YOUR-API-KEY>' \
--form 'business_id="1234567-8"' \
--form 'transaction_id="34b9f4b4c9774ff8b2fa0827b2ace014"' \
--form 'tos_function_id="c1f23d3a9eea4b43829cba5a68401799"' \
--form 'tos_record_id="ba3cb4fabe9b45f48d04db0a4422bf41"' \
--form 'metadata="{\"created_by\": \"alex\"}"' \
--form 'type="contract"'
```
