### PR TITLE
ATV-53 | Don't change uploaded file permissions

### DIFF
--- a/atv/settings.py
+++ b/atv/settings.py
@@ -85,6 +85,8 @@ STATIC_ROOT = env("STATIC_ROOT")
 MEDIA_URL = env("MEDIA_URL")
 STATIC_URL = env("STATIC_URL")
 
+FILE_UPLOAD_PERMISSIONS = None
+
 ROOT_URLCONF = "atv.urls"
 WSGI_APPLICATION = "atv.wsgi.application"
 


### PR DESCRIPTION

## Description :sparkles:

Changing permissions will result in an error since the file mount (in production) enforces permissive permissions by default (777). Due to the permissive default permissions we should be able to just skip the permission change.


## Issues :bug:
### Closes :no_good_woman:
**[ATV-53](https://helsinkisolutionoffice.atlassian.net/browse/ATV-53):** Fix file volume permissions
- [Sentry bug](https://sentry.io/organizations/city-of-helsinki/issues/2585083468/?project=5826284)

