### PR TITLE
ATV-1 | Add content input for Document creation

### DIFF
--- a/documents/serializers/document.py
+++ b/documents/serializers/document.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.core.serializers.json import DjangoJSONEncoder
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 
@@ -11,8 +12,13 @@ from .attachment import AttachmentSerializer, CreateAnonymousAttachmentSerialize
 class DocumentSerializer(serializers.ModelSerializer):
     """Basic "read" serializer for the Document model"""
 
-    user_id = serializers.UUIDField(source="user.id", required=False, default=None)
-    attachments = AttachmentSerializer(many=True)
+    user_id = serializers.UUIDField(
+        source="user.uuid", required=False, default=None, read_only=True
+    )
+    attachments = AttachmentSerializer(many=True, required=False)
+    content = serializers.JSONField(
+        required=True, decoder=None, encoder=DjangoJSONEncoder
+    )
 
     class Meta:
         model = Document
@@ -28,6 +34,7 @@ class DocumentSerializer(serializers.ModelSerializer):
             "tos_function_id",
             "tos_record_id",
             "metadata",
+            "content",
             "draft",
             "locked_after",
             "attachments",
@@ -43,6 +50,9 @@ class CreateAnonymousDocumentSerializer(serializers.ModelSerializer):
     """
 
     attachments = serializers.ListField(child=serializers.FileField(), required=False)
+    content = serializers.JSONField(
+        required=True, decoder=None, encoder=DjangoJSONEncoder
+    )
 
     class Meta:
         model = Document
@@ -54,6 +64,7 @@ class CreateAnonymousDocumentSerializer(serializers.ModelSerializer):
             "tos_function_id",
             "tos_record_id",
             "metadata",
+            "content",
             "draft",
             "locked_after",
             "attachments",

--- a/documents/tests/snapshots/snap_test_api_create_document.py
+++ b/documents/tests/snapshots/snap_test_api_create_document.py
@@ -28,6 +28,14 @@ snapshots["test_create_document 1"] = {
         },
     ],
     "business_id": "1234567-8",
+    "content": {
+        "formData": {
+            "birthDate": "3.11.1957",
+            "firstName": "Dolph",
+            "lastName": "Lundgren",
+        },
+        "reasonForApplication": "No reason, just testing",
+    },
     "created_at": "2021-06-30T12:00:00+03:00",
     "draft": False,
     "id": "2d2b7a36-a306-4e35-990f-13aea04263ff",


### PR DESCRIPTION
## Description :sparkles:
The Document create endpoint does not support submitting the `content`, which is the main reason of the service, so without it the whole Document is useless. This fix adds the `content` to the serializers to allow saving it. 

## Issues :bug:
### Closes :no_good_woman:
**[ATV-1](https://helsinkisolutionoffice.atlassian.net/browse/ATV-1):** As an anonymous user, I want to submit a public RFI, to obtain a public document

### Related :handshake:
#10 

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest documents/tests/test_api_create_document.py
```

### Manual testing :construction_worker_man:
```shell
curl --location --request POST 'http://localhost:8000/v1/documents/' \
--header 'X-Api-Key: YOUR-API-KEY' \
--form 'business_id="1234567-8"' \
--form 'transaction_id="34b9f4b4c9774ff8b2fa0827b2ace014"' \
--form 'tos_function_id="c1f23d3a9eea4b43829cba5a68401799"' \
--form 'tos_record_id="ba3cb4fabe9b45f48d04db0a4422bf41"' \
--form 'metadata="{\"created_by\": \"alex\"}"' \
--form 'type="contract"' \
--form 'content="{\"value\": \"secret_stuff\"}"' \
--form 'status="yes"'
```

Response:
```json
{
    "id": "ef5402b8-500c-4f97-bf77-f92bf9abea20",
    "created_at": "2021-08-31T11:22:07.403313+03:00",
    "updated_at": "2021-08-31T11:22:07.403335+03:00",
    "status": "yes",
    "type": "contract",
    "transaction_id": "34b9f4b4c9774ff8b2fa0827b2ace014",
    "user_id": null,
    "business_id": "1234567-8",
    "tos_function_id": "c1f23d3a9eea4b43829cba5a68401799",
    "tos_record_id": "ba3cb4fabe9b45f48d04db0a4422bf41",
    "metadata": {
        "created_by": "alex"
    },
    "content": {
        "value": "secret_stuff"
    },
    "draft": false,
    "locked_after": null,
    "attachments": []
}
```