### PR TITLE
ATV-63 | Document update endpoint

### DIFF
--- a/atv/decorators.py
+++ b/atv/decorators.py
@@ -27,6 +27,11 @@ def _use_request_tests(*test_funcs):
     return decorator
 
 
+def _require_authenticated(request):
+    if not request.user.is_authenticated:
+        raise PermissionDenied(_("You do not have permission to perform this action."))
+
+
 def _require_service(request):
     if not request.service:
         raise ServiceNotIdentifiedError("No service identified")
@@ -64,6 +69,14 @@ def staff_required(required_permission=ServicePermissions.VIEW_DOCUMENTS):
     @_use_request_tests(_require_service_permission(required_permission.value))
     def check_permission():
         f"""Decorator that checks for {required_permission} permission."""
+
+    return check_permission
+
+
+def login_required():
+    @_use_request_tests(_require_authenticated)
+    def check_permission():
+        """Decorator for checking that the user is logged in"""
 
     return check_permission
 

--- a/documents/serializers/__init__.py
+++ b/documents/serializers/__init__.py
@@ -1,8 +1,9 @@
-from .attachment import AttachmentSerializer
+from .attachment import AttachmentSerializer, CreateAttachmentSerializer
 from .document import CreateAnonymousDocumentSerializer, DocumentSerializer
 
 __all__ = [
     "AttachmentSerializer",
     "CreateAnonymousDocumentSerializer",
+    "CreateAttachmentSerializer",
     "DocumentSerializer",
 ]

--- a/documents/serializers/attachment.py
+++ b/documents/serializers/attachment.py
@@ -32,7 +32,7 @@ class AttachmentSerializer(serializers.ModelSerializer):
         return instance.uri
 
 
-class CreateAnonymousAttachmentSerializer(serializers.ModelSerializer):
+class CreateAttachmentSerializer(serializers.ModelSerializer):
     """Create an Attachment associated to an anonymous document."""
 
     class Meta:

--- a/documents/tests/snapshots/snap_test_api_patch_document.py
+++ b/documents/tests/snapshots/snap_test_api_patch_document.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import Snapshot
+
+snapshots = Snapshot()
+
+snapshots["test_update_document_owner 1"] = {
+    "business_id": "1234567-8",
+    "content": {
+        "formData": {
+            "birthDate": "3.11.1957",
+            "firstName": "Dolph",
+            "lastName": "Lundgren",
+        },
+        "reasonForApplication": "No reason, just testing",
+    },
+    "created_at": "2021-06-30T12:00:00+03:00",
+    "draft": True,
+    "id": "2d2b7a36-a306-4e35-990f-13aea04263ff",
+    "locked_after": None,
+    "metadata": {"created_by": "alex", "testing": True},
+    "status": "handled",
+    "tos_function_id": "f917d43aab76420bb2ec53f6684da7f7",
+    "tos_record_id": "89837a682b5d410e861f8f3688154163",
+    "transaction_id": "cf0a341b-6bfd-4f59-8d7c-87bf62ba837b",
+    "type": "mysterious form",
+    "updated_at": "2021-06-30T12:00:00+03:00",
+}
+
+snapshots["test_update_document_staff 1"] = {
+    "attachments": [],
+    "business_id": "1234567-8",
+    "content": "",
+    "created_at": "2021-06-30T12:00:00+03:00",
+    "draft": True,
+    "id": "2d2b7a36-a306-4e35-990f-13aea04263ff",
+    "locked_after": None,
+    "metadata": {"created_by": "alex", "testing": True},
+    "status": "handled",
+    "tos_function_id": "f917d43aab76420bb2ec53f6684da7f7",
+    "tos_record_id": "89837a682b5d410e861f8f3688154163",
+    "transaction_id": "cf0a341b-6bfd-4f59-8d7c-87bf62ba837b",
+    "type": "mysterious form",
+    "updated_at": "2021-06-30T12:00:00+03:00",
+}
+
+snapshots["test_update_document_staff_non_draft 1"] = {
+    "attachments": [],
+    "business_id": "1234567-8",
+    "content": "",
+    "created_at": "2021-06-30T12:00:00+03:00",
+    "draft": False,
+    "id": "2d2b7a36-a306-4e35-990f-13aea04263ff",
+    "locked_after": None,
+    "metadata": {"created_by": "alex", "testing": True},
+    "status": "handled",
+    "tos_function_id": "f917d43aab76420bb2ec53f6684da7f7",
+    "tos_record_id": "89837a682b5d410e861f8f3688154163",
+    "transaction_id": "cf0a341b-6bfd-4f59-8d7c-87bf62ba837b",
+    "type": "mysterious form",
+    "updated_at": "2021-06-30T12:00:00+03:00",
+}

--- a/documents/tests/test_api_patch_document.py
+++ b/documents/tests/test_api_patch_document.py
@@ -1,0 +1,362 @@
+import json
+from uuid import uuid4
+
+from dateutil.relativedelta import relativedelta
+from dateutil.utils import today
+from django.contrib.auth import get_user
+from django.core.files.uploadedfile import SimpleUploadedFile
+from freezegun import freeze_time
+from guardian.shortcuts import assign_perm
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+from atv.tests.factories import GroupFactory
+from documents.models import Document
+from documents.tests.factories import DocumentFactory
+from services.enums import ServicePermissions
+from utils.tests import assert_in_errors
+
+VALID_DOCUMENT_DATA = {
+    "status": "handled",
+    "type": "mysterious form",
+    "transaction_id": "cf0a341b-6bfd-4f59-8d7c-87bf62ba837b",
+    "business_id": "1234567-8",
+    "tos_function_id": "f917d43aab76420bb2ec53f6684da7f7",
+    "tos_record_id": "89837a682b5d410e861f8f3688154163",
+    "metadata": json.dumps({"created_by": "alex", "testing": True}),
+    "content": json.dumps(
+        {
+            "formData": {
+                "firstName": "Dolph",
+                "lastName": "Lundgren",
+                "birthDate": "3.11.1957",
+            },
+            "reasonForApplication": "No reason, just testing",
+        }
+    ),
+}
+
+
+# OWNER-RELATED ACTIONS
+
+
+@freeze_time("2021-06-30T12:00:00+03:00")
+def test_update_document_owner(
+    user_api_client,
+    snapshot,
+):
+    user = get_user(user_api_client)
+
+    document = DocumentFactory(
+        id="2d2b7a36-a306-4e35-990f-13aea04263ff",
+        draft=True,
+        user=user,
+    )
+    assert Document.objects.count() == 1
+    assert document.attachments.count() == 0
+
+    data = {
+        **VALID_DOCUMENT_DATA,
+        "attachments": [
+            SimpleUploadedFile(
+                "document1.pdf", b"file_content", content_type="application/pdf"
+            ),
+        ],
+    }
+
+    response = user_api_client.patch(
+        reverse("documents-detail", args=[document.id]),
+        data,
+        format="multipart",
+    )
+
+    assert Document.objects.count() == 1
+    assert document.attachments.count() == 1
+
+    body = response.json()
+    attachment = document.attachments.first()
+
+    assert body.pop("attachments", []) == [
+        {
+            "created_at": "2021-06-30T12:00:00+03:00",
+            "filename": "document1.pdf",
+            "href": f"http://testserver/v1/documents/2d2b7a36-a306-4e35-990f-13aea04263ff/attachments/{attachment.id}/",
+            "id": attachment.id,
+            "media_type": "application/pdf",
+            "size": 12,
+            "updated_at": "2021-06-30T12:00:00+03:00",
+        }
+    ]
+
+    assert response.status_code == status.HTTP_200_OK
+    assert body.pop("user_id", None) == str(document.user.uuid) == str(user.uuid)
+
+    snapshot.assert_match(body)
+
+
+@freeze_time("2021-06-30T12:00:00+03:00")
+def test_update_document_owner_someone_elses_document(
+    user_api_client,
+):
+    document = DocumentFactory(
+        id="2d2b7a36-a306-4e35-990f-13aea04263ff",
+        draft=True,
+    )
+
+    # Check that the owner of the document is different than the one
+    # making the request
+    assert document.user != get_user(user_api_client)
+
+    response = user_api_client.patch(
+        reverse("documents-detail", args=[document.id]),
+        {},  # No need to have any actual data
+    )
+
+    body = response.json()
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert (
+        body.get("detail", "") == "You do not have permission to perform this action."
+    )
+
+
+@freeze_time("2021-06-30T12:00:00+03:00")
+def test_update_document_owner_non_draft(
+    user_api_client,
+):
+    document = DocumentFactory(
+        id="2d2b7a36-a306-4e35-990f-13aea04263ff",
+        draft=False,
+        user=get_user(user_api_client),
+    )
+
+    response = user_api_client.patch(
+        reverse("documents-detail", args=[document.id]),
+        {},  # No need to have any actual data
+    )
+
+    body = response.json()
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert_in_errors("You cannot modify a document which is not a draft", body)
+
+
+@freeze_time("2021-06-30T12:00:00")
+def test_update_document_owner_after_lock_date(
+    user_api_client,
+):
+    document = DocumentFactory(
+        id="2d2b7a36-a306-4e35-990f-13aea04263ff",
+        locked_after=today() - relativedelta(days=1),
+        draft=True,
+        user=get_user(user_api_client),
+    )
+
+    response = user_api_client.patch(
+        reverse("documents-detail", args=[document.id]),
+        {},  # No need to have any actual data
+    )
+
+    body = response.json()
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert_in_errors("Cannot update a Document after it has been locked", body)
+
+
+# STAFF-RELATED ACTION
+
+
+@freeze_time("2021-06-30T12:00:00+03:00")
+def test_update_document_staff(
+    user_api_client,
+    service,
+    snapshot,
+):
+    group = GroupFactory(name=service.name)
+    user = get_user(user_api_client)
+    assign_perm(ServicePermissions.MANAGE_DOCUMENTS.value, group, service)
+    user.groups.add(group)
+
+    document = DocumentFactory(
+        id="2d2b7a36-a306-4e35-990f-13aea04263ff",
+        draft=True,
+        service=service,
+    )
+    assert Document.objects.count() == 1
+
+    data = {**VALID_DOCUMENT_DATA}
+    data.pop("content")
+
+    response = user_api_client.patch(
+        reverse("documents-detail", args=[document.id]),
+        data,
+    )
+
+    assert Document.objects.count() == 1
+
+    body = response.json()
+
+    assert response.status_code == status.HTTP_200_OK
+    assert body.pop("user_id", None) == str(document.user.uuid)
+    snapshot.assert_match(body)
+
+
+@freeze_time("2021-06-30T12:00:00+03:00")
+def test_update_document_staff_non_draft(
+    user_api_client,
+    service,
+    snapshot,
+):
+    group = GroupFactory(name=service.name)
+    user = get_user(user_api_client)
+    assign_perm(ServicePermissions.MANAGE_DOCUMENTS.value, group, service)
+    user.groups.add(group)
+
+    document = DocumentFactory(
+        id="2d2b7a36-a306-4e35-990f-13aea04263ff",
+        service=service,
+        draft=False,
+    )
+
+    data = {**VALID_DOCUMENT_DATA}
+    data.pop("content")
+
+    response = user_api_client.patch(
+        reverse("documents-detail", args=[document.id]),
+        data,
+    )
+
+    body = response.json()
+
+    assert response.status_code == status.HTTP_200_OK
+    assert body.pop("user_id", None) == str(document.user.uuid)
+    snapshot.assert_match(body)
+
+
+@freeze_time("2021-06-30T12:00:00")
+def test_update_document_staff_after_lock_date(
+    user_api_client,
+    service,
+):
+    group = GroupFactory(name=service.name)
+    user = get_user(user_api_client)
+    assign_perm(ServicePermissions.MANAGE_DOCUMENTS.value, group, service)
+    user.groups.add(group)
+
+    document = DocumentFactory(
+        id="2d2b7a36-a306-4e35-990f-13aea04263ff",
+        locked_after=today() - relativedelta(days=1),
+        service=service,
+    )
+
+    response = user_api_client.patch(
+        reverse("documents-detail", args=[document.id]),
+        {},  # No need to have any actual data
+    )
+
+    body = response.json()
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert_in_errors("Cannot update a Document after it has been locked", body)
+
+
+@freeze_time("2021-06-30T12:00:00")
+def test_update_document_staff_another_service(
+    user_api_client,
+    service,
+):
+    group = GroupFactory(name=service.name)
+    user = get_user(user_api_client)
+    assign_perm(ServicePermissions.MANAGE_DOCUMENTS.value, group, service)
+    user.groups.add(group)
+
+    document = DocumentFactory(
+        id="2d2b7a36-a306-4e35-990f-13aea04263ff",
+    )
+
+    response = user_api_client.patch(
+        reverse("documents-detail", args=[document.id]),
+        {},  # No need to have any actual data
+    )
+
+    body = response.json()
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert (
+        body.get("detail", "") == "You do not have permission to perform this action."
+    )
+
+
+@freeze_time("2021-06-30T12:00:00")
+def test_update_document_staff_update_content_fails(
+    user_api_client,
+    service,
+):
+    group = GroupFactory(name=service.name)
+    user = get_user(user_api_client)
+    assign_perm(ServicePermissions.MANAGE_DOCUMENTS.value, group, service)
+    user.groups.add(group)
+
+    document = DocumentFactory(
+        id="2d2b7a36-a306-4e35-990f-13aea04263ff",
+        service=service,
+    )
+
+    response = user_api_client.patch(
+        reverse("documents-detail", args=[document.id]),
+        {"content": json.dumps({"value": "secret stuff"})},
+    )
+
+    body = response.json()
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert_in_errors("You cannot modify the contents of the document", body)
+
+
+@freeze_time("2021-06-30T12:00:00")
+def test_update_document_staff_update_attachments_fails(
+    user_api_client,
+    service,
+):
+    group = GroupFactory(name=service.name)
+    user = get_user(user_api_client)
+    assign_perm(ServicePermissions.MANAGE_DOCUMENTS.value, group, service)
+    user.groups.add(group)
+
+    document = DocumentFactory(
+        id="2d2b7a36-a306-4e35-990f-13aea04263ff",
+        service=service,
+    )
+
+    response = user_api_client.patch(
+        reverse("documents-detail", args=[document.id]),
+        {
+            "attachments": [
+                SimpleUploadedFile(
+                    "document1.pdf", b"file_content", content_type="application/pdf"
+                )
+            ]
+        },
+    )
+
+    body = response.json()
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert_in_errors("You cannot modify the contents of the document", body)
+
+
+# OTHER STUFF
+
+
+@freeze_time("2021-06-30T12:00:00")
+def test_update_document_not_found(superuser_api_client):
+    response = superuser_api_client.patch(
+        reverse("documents-detail", args=[uuid4()]),
+        {},  # No need to have any actual data
+    )
+
+    body = response.json()
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    assert body.get("detail", "") == "Document matching query does not exist."

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -7,6 +7,7 @@ freezegun
 ipython
 isort
 pep8-naming
+pre-commit
 pytest
 pytest-cov
 pytest-django

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,20 +6,28 @@
 #
 appdirs==1.4.4
     # via black
+appnope==0.1.2
+    # via ipython
 attrs==21.2.0
     # via
     #   flake8-bugbear
     #   pytest
 backcall==0.2.0
     # via ipython
+backports.entry-points-selectable==1.1.0
+    # via virtualenv
 black==21.7b0
     # via -r requirements-dev.in
+cfgv==3.3.1
+    # via pre-commit
 click==8.0.1
     # via black
 coverage==5.5
     # via pytest-cov
 decorator==5.0.9
     # via ipython
+distlib==0.3.2
+    # via virtualenv
 factory-boy==3.2.0
     # via
     #   -r requirements-dev.in
@@ -28,6 +36,8 @@ faker==8.11.0
     # via factory-boy
 fastdiff==0.3.0
     # via snapshottest
+filelock==3.0.12
+    # via virtualenv
 flake8==3.9.2
     # via
     #   -r requirements-dev.in
@@ -40,6 +50,8 @@ flake8-polyfill==1.0.2
     # via pep8-naming
 freezegun==1.1.0
     # via -r requirements-dev.in
+identify==2.2.13
+    # via pre-commit
 inflection==0.5.1
     # via pytest-factoryboy
 iniconfig==1.1.1
@@ -58,6 +70,8 @@ mccabe==0.6.1
     # via flake8
 mypy-extensions==0.4.3
     # via black
+nodeenv==1.6.0
+    # via pre-commit
 packaging==21.0
     # via
     #   -c requirements.txt
@@ -72,8 +86,12 @@ pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
+platformdirs==2.3.0
+    # via virtualenv
 pluggy==0.13.1
     # via pytest
+pre-commit==2.14.1
+    # via -r requirements-dev.in
 prompt-toolkit==3.0.19
     # via ipython
 ptyprocess==0.7.0
@@ -106,6 +124,8 @@ python-dateutil==2.8.2
     # via
     #   faker
     #   freezegun
+pyyaml==5.4.1
+    # via pre-commit
 regex==2021.8.3
     # via black
 six==1.16.0
@@ -113,6 +133,7 @@ six==1.16.0
     #   -c requirements.txt
     #   python-dateutil
     #   snapshottest
+    #   virtualenv
 snapshottest==0.6.0
     # via -r requirements-dev.in
 termcolor==1.1.0
@@ -121,6 +142,7 @@ text-unidecode==1.3
     # via faker
 toml==0.10.2
     # via
+    #   pre-commit
     #   pytest
     #   pytest-cov
 tomli==1.2.1
@@ -129,6 +151,8 @@ traitlets==5.0.5
     # via
     #   ipython
     #   matplotlib-inline
+virtualenv==20.7.2
+    # via pre-commit
 wasmer==1.0.0
     # via fastdiff
 wasmer-compiler-cranelift==1.0.0

--- a/utils/tests.py
+++ b/utils/tests.py
@@ -1,0 +1,3 @@
+def assert_in_errors(message, response: dict):
+    assert "errors" in response
+    assert str(message) in response.get("errors")


### PR DESCRIPTION
## Description :sparkles:
* Add support for updating documents with PATCH request
* Remove some redundant checks from the POST Document

## Issues :bug:
### Closes :no_good_woman:
**[ATV-63](https://helsinkisolutionoffice.atlassian.net/browse/ATV-63):** Add PATCH functionality for document metadata

### Related :handshake:
Requires that #15 is merged first

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest documents/tests/test_api_patch_document.py
```

## Additional notes 📝 
For now, this has to be done through the browser, since it requires the Django login for authentication 

