### PR TITLE
ATV-68 | Add Swagger documentation for the live functionalities

### DIFF
--- a/atv/settings.py
+++ b/atv/settings.py
@@ -44,6 +44,7 @@ env = environ.Env(
     API_KEY_CUSTOM_HEADER=(str, "HTTP_X_API_KEY"),
     FIELD_ENCRYPTION_KEYS=(list, []),
     ENABLE_AUTOMATIC_ATTACHMENT_FILE_DELETION=(bool, True),
+    ENABLE_SWAGGER_UI=(bool, True),
 )
 if os.path.exists(env_file):
     env.read_env(env_file)
@@ -118,6 +119,7 @@ INSTALLED_APPS = [
     "corsheaders",
     "encrypted_fields",
     "guardian",
+    "drf_spectacular",
     # Local apps
     "users",
     "services",
@@ -159,7 +161,9 @@ CORS_ORIGIN_ALLOW_ALL = env.bool("CORS_ORIGIN_ALLOW_ALL")
 REST_FRAMEWORK = {
     "DEFAULT_PERMISSION_CLASSES": [
         "rest_framework.permissions.IsAdminUser",
-    ]
+    ],
+    "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+    "DEFAULT_PARENT_LOOKUP_KWARG_NAME_PREFIX": "",
 }
 
 ATTACHMENT_MEDIA_DIR = "attachments"
@@ -192,6 +196,15 @@ if DEBUG and not FIELD_ENCRYPTION_KEYS:
 
 if not DEBUG and DEBUG_FIELD_ENCRYPTION_KEY in FIELD_ENCRYPTION_KEYS:
     raise ImproperlyConfigured("Cannot use the debug encryption key in production")
+
+# API Documentation
+ENABLE_SWAGGER_UI = env("ENABLE_SWAGGER_UI")
+
+SPECTACULAR_SETTINGS = {
+    "TITLE": " Asiointitietovaranto ",
+    "DESCRIPTION": "Asiointitietovaranto REST API",
+    "VERSION": "0.0.1",
+}
 
 LOGGING = {
     "version": 1,

--- a/atv/urls.py
+++ b/atv/urls.py
@@ -1,6 +1,12 @@
+from django.conf import settings
 from django.contrib import admin
 from django.http import HttpResponse
 from django.urls import include, path
+from drf_spectacular.views import (
+    SpectacularAPIView,
+    SpectacularRedocView,
+    SpectacularSwaggerView,
+)
 from rest_framework_extensions.routers import ExtendedSimpleRouter
 
 from documents.api import AttachmentViewSet, DocumentViewSet
@@ -11,7 +17,7 @@ router.register(r"documents", DocumentViewSet, basename="documents").register(
     r"attachments",
     AttachmentViewSet,
     basename="documents-attachments",
-    parents_query_lookups=["document"],
+    parents_query_lookups=["document_id"],
 )
 
 
@@ -21,9 +27,26 @@ urlpatterns = [
 ]
 
 
+if settings.ENABLE_SWAGGER_UI:
+    urlpatterns += [
+        path("v1/schema/", SpectacularAPIView.as_view(), name="schema"),
+        path(
+            "v1/schema/swagger/",
+            SpectacularSwaggerView.as_view(url_name="schema"),
+            name="swagger",
+        ),
+        path(
+            "v1/schema/redoc/",
+            SpectacularRedocView.as_view(url_name="schema"),
+            name="redoc",
+        ),
+    ]
+
 #
 # Kubernetes liveness & readiness probes
 #
+
+
 def healthz(*args, **kwargs):
     return HttpResponse(status=200)
 

--- a/documents/api/__init__.py
+++ b/documents/api/__init__.py
@@ -1,0 +1,6 @@
+from .viewsets import AttachmentViewSet, DocumentViewSet
+
+__all__ = [
+    "AttachmentViewSet",
+    "DocumentViewSet",
+]

--- a/documents/api/docs.py
+++ b/documents/api/docs.py
@@ -1,0 +1,391 @@
+from drf_spectacular.utils import (
+    extend_schema,
+    inline_serializer,
+    OpenApiExample,
+    OpenApiResponse,
+)
+from rest_framework import serializers, status
+
+from documents.serializers import DocumentSerializer
+
+error_serializer = inline_serializer(
+    "ErrorResponse",
+    fields={
+        "errors": inline_serializer(
+            "Error",
+            fields={
+                "code": serializers.CharField(),
+                "description": serializers.CharField(),
+            },
+            many=True,
+        )
+    },
+)
+
+example_error = OpenApiExample(
+    name="ErrorExample",
+    response_only=True,
+    status_codes=[
+        str(status.HTTP_400_BAD_REQUEST),
+        str(status.HTTP_500_INTERNAL_SERVER_ERROR),
+    ],
+    value={
+        "errors": [
+            {
+                "code": "GENERAL_ERROR",
+                "description": "Something went wrong, we don't know what.",
+            }
+        ]
+    },
+)
+
+example_attachment = OpenApiExample(
+    name="AttachmentExample",
+    response_only=True,
+    status_codes=[str(status.HTTP_200_OK), str(status.HTTP_201_CREATED)],
+    value={
+        "id": 12994,
+        "createdAt": "2021-04-21T13:17:15.511Z",
+        "updatedAt": "2021-04-21T13:17:15.511Z",
+        "filename": "high-school-diploma.pdf",
+        "mediaType": "application/pdf",
+        "size": 123223,
+        "href": "https://transactions-storage.com/api/v1/documents/97c0b7a5-0b4c-4470-9a41-48d79454f233/"
+        "attachments/12994",
+    },
+)
+
+example_document = OpenApiExample(
+    name="DocumentExample",
+    response_only=True,
+    status_codes=[str(status.HTTP_200_OK), str(status.HTTP_201_CREATED)],
+    value={
+        "id": "f6fe8acc-3b91-41b3-a176-9d2feab2d2bb",
+        "createdAt": "2021-04-21T13:17:15.511Z",
+        "updatedAt": "2021-04-21T13:17:15.511Z",
+        "status": "BEING_PROCESSED",
+        "type": "APPLICATION_FOR_RESIDENTIAL_PARKING_PERMIT",
+        "transactionId": "some transaction id 1234",
+        "userId": "97c0b7a5-0b4c-4470-9a41-48d79454f233",
+        "businessId": "0874691-5",
+        "tosFunctionId": "eb30af1d9d654ebc98287ca25f231bf6",
+        "tosRecordId": "521317ab6b4a4157a1714f5cc9fd69de",
+        "metadata": {
+            "some-field": "some value relevant to the calling service",
+            "status": "some-arbitrary-status",
+            "handler": "sstallone",
+        },
+        "draft": True,
+        "lockedAfter": "2021-08-01T00:00:00.0Z",
+        "content": {
+            "formData": {
+                "firstName": "Dolph",
+                "lastName": "Lundgren",
+                "birthDate": "3.11.1957",
+            },
+            "reasonForApplication": "No reason, just testing",
+        },
+        "attachments": [
+            {
+                "id": 12994,
+                "createdAt": "2021-04-21T13:17:15.511Z",
+                "updatedAt": "2021-04-21T13:17:15.511Z",
+                "filename": "high-school-diploma.pdf",
+                "mediaType": "application/pdf",
+                "size": 123223,
+                "href": "https://transactions-storage.com/api/v1/documents/97c0b7a5-0b4c-4470-9a41-48d79454f233/"
+                "attachments/12994",
+            },
+            {
+                "id": 12995,
+                "createdAt": "2021-04-21T13:17:25.511Z",
+                "updatedAt": "2021-04-21T13:17:25.511Z",
+                "filename": "my-face.jpeg",
+                "mediaType": "image/jpeg",
+                "size": 512884,
+                "href": "https://transactions-storage.com/api/v1/documents/97c0b7a5-0b4c-4470-9a41-48d79454f233/"
+                "attachments/12995",
+            },
+        ],
+        "href": "https://transactions-storage.com/api/v1/documents/97c0b7a5-0b4c-4470-9a41-48d79454f233",
+    },
+)
+
+
+def _base_401_response(custom_message: str = None) -> OpenApiResponse:
+    return OpenApiResponse(
+        description=custom_message
+        or "Request’s credentials are missing or invalid. A valid JWT authentication is required.",
+    )
+
+
+def _base_400_response(custom_message: str = None) -> OpenApiResponse:
+    return OpenApiResponse(
+        response=error_serializer,
+        description=custom_message
+        or "One or more of the given parameters were invalid.",
+    )
+
+
+def _base_500_response(custom_message: str = None) -> OpenApiResponse:
+    return OpenApiResponse(
+        response=error_serializer,
+        description=custom_message
+        or "There has been an unexpected error during the call.",
+    )
+
+
+attachment_viewset_docs = {
+    # TODO: Not implemented yet
+    "retrieve": extend_schema(exclude=True),
+    #     summary="Download a document's attachment",
+    #     description="Permission to access the attachment is checked based on the containing document as follows:\n"
+    #     "* Admin users are allowed access to the attachment if the containing document was stored using the service "
+    #     "they are using and whose admins they are.\n"
+    #     "* Authenticated users are allowed access to the attachment if they are the owner of the containing document "
+    #     "or the containing document is owned by an organization and the user has permission to act on behalf "
+    #     "of that organization.",
+    #     responses={
+    #         (status.HTTP_200_OK, "application/octet-stream"): OpenApiResponse(
+    #             description="Returns the attachment as a downloadable file.",
+    #         ),
+    #         (status.HTTP_400_BAD_REQUEST, "application/json"): _base_400_response(),
+    #         status.HTTP_401_UNAUTHORIZED: _base_401_response(),
+    #         status.HTTP_403_FORBIDDEN: OpenApiResponse(
+    #             description="The authenticated user lacks the proper permissions to access the document. "
+    #             "Depending on the requested document, "
+    #             "either the user does not belong to the admin group of the service which owns the document, "
+    #             "the user does not own the document or the user does not have permission to act on behalf "
+    #             "of the organization which owns the document."
+    #         ),
+    #         status.HTTP_404_NOT_FOUND: OpenApiResponse(
+    #             description="No document was found with `documentId` or the document did not have "
+    #             "an attachment `attachmentId`."
+    #         ),
+    #         status.HTTP_500_INTERNAL_SERVER_ERROR: _base_500_response(),
+    #     },
+    #     examples=[example_attachment, example_error],
+    # ),
+    # TODO: Not implemented yet
+    "create": extend_schema(exclude=True),
+    #     summary="Upload a new attachment to a document",
+    #     description="Permission to access the document is checked as follows:\n"
+    #     "* Authenticated users are allowed access to the document if they are the owner of the document "
+    #     "or the document is owned by an organization and the user has permission to act on behalf "
+    #     "of that organization.\n\n"
+    #     "The following rules apply:\n"
+    #     "* Drafts may be modified by the owning user, "
+    #     "the owning service's admin or an organization's representative, "
+    #     "if the document is owned by an organization.\n"
+    #     "* Non-drafts may be modified by an admin.\n"
+    #     "* Documents may not be modified if their `lockedAfter` date has passed.",
+    #     #     # TODO: Need to add a serializer for plain file
+    #     #     request=None,
+    #     responses={
+    #         (status.HTTP_201_CREATED, "application/json"): OpenApiResponse(
+    #             response=AttachmentSerializer,
+    #             description="The attachment was uploaded successfully. "
+    #             "The attachments information is returned in the response body.",
+    #         ),
+    #         (status.HTTP_400_BAD_REQUEST, "application/json"): _base_400_response(),
+    #         status.HTTP_401_UNAUTHORIZED: _base_401_response(),
+    #         status.HTTP_403_FORBIDDEN: OpenApiResponse(
+    #             description="The request contains an organization ID and the currently authenticated user "
+    #             "does not have permission to act on behalf of that organization."
+    #         ),
+    #         status.HTTP_500_INTERNAL_SERVER_ERROR: _base_500_response(),
+    #     },
+    #     examples=[example_attachment, example_error],
+    # ),
+    # TODO: Not implemented yet
+    "destroy": extend_schema(exclude=True),
+    #     summary="Remove a document's attachment",
+    #     description="Permission to remove the attachment is checked based on the containing document as follows:\n"
+    #     "* Authenticated users are allowed to remove the attachment if they are the owner of the containing document "
+    #     "or the containing document is owned by an organization and the user has permission to act on behalf "
+    #     "of that organization.\n\n"
+    #     "The following rules apply:\n"
+    #     "* Attachments of drafts may be removed by the owning user or an organization's representative, "
+    #     "if the containing document is owned by an organization."
+    #     "* Attachments may not be removed if the containing document's `lockedAfter` date has passed. "
+    #     "This should be done by removing the whole document.",
+    #     responses={
+    #         status.HTTP_204_NO_CONTENT: OpenApiResponse(
+    #             description="The attachment was removed successfully.",
+    #         ),
+    #         (status.HTTP_400_BAD_REQUEST, "application/json"): _base_400_response(),
+    #         status.HTTP_401_UNAUTHORIZED: _base_401_response(),
+    #         status.HTTP_403_FORBIDDEN: OpenApiResponse(
+    #             description="The authenticated user lacks the proper permissions to access the document. "
+    #             "Depending on the requested document, "
+    #             "either the user does not belong to the admin group of the service which owns the document, "
+    #             "the user does not own the document or the user does not have permission to act on behalf "
+    #             "of the organization which owns the document."
+    #         ),
+    #         status.HTTP_404_NOT_FOUND: OpenApiResponse(
+    #             description="No document was found with `documentId` or the document did not have "
+    #             "an attachment `attachmentId`."
+    #         ),
+    #         status.HTTP_500_INTERNAL_SERVER_ERROR: _base_500_response(),
+    #     },
+    #     examples=[example_error],
+    # ),
+    # Not implementing
+    "list": extend_schema(exclude=True),
+    "update": extend_schema(exclude=True),
+    "partial_update": extend_schema(exclude=True),
+}
+
+document_viewset_docs = {
+    "list": extend_schema(
+        summary="Search for documents",
+        description="This endpoint can be used to fetch a list of documents. "
+        "The list can be filtered, sorted and paged using the appropriate query parameters.\n\n"
+        "The results will contain only those documents which are allowed for the current user.\n\n"
+        "* Admin users are allowed to fetch all documents which were stored using the service "
+        "they are using and whose admins they are.\n"
+        "* Authenticated users are allowed to fetch documents which are owned by them and "
+        "which were stored using the service they are using. "
+        "Documents owned by an organization are not returned even if such a document was created by the current user.\n"
+        "* Authenticated users may fetch documents owned by an organization by giving the organization's business ID "
+        "in the search parameters. In this case the user's permission to act on behalf of the organization "
+        "is verified and the results will contain only documents which are owned by the given organization.",
+        responses={
+            (status.HTTP_200_OK, "application/json"): OpenApiResponse(
+                response=DocumentSerializer,
+                description="Returns a list of documents with the given criteria. "
+                "An empty list is returned if there are no results.",
+            ),
+            (status.HTTP_400_BAD_REQUEST, "application/json"): _base_400_response(),
+            status.HTTP_401_UNAUTHORIZED: _base_401_response(),
+            status.HTTP_403_FORBIDDEN: OpenApiResponse(
+                description="The search parameters contain an organization ID and the currently authenticated user does"
+                "not have permission to act on behalf of that organization."
+            ),
+            status.HTTP_500_INTERNAL_SERVER_ERROR: _base_500_response(),
+        },
+        examples=[example_document, example_error],
+    ),
+    "retrieve": extend_schema(
+        summary="Fetch a document by ID",
+        description="This endpoint allows a user to fetch a document's details.\n\n"
+        "Permission to access the document is checked as follows:\n\n"
+        "* Admin users are allowed access to the document if it was stored using the service "
+        "they are using and whose admins they are.\n"
+        "* Authenticated users are allowed access to the document if they are the owner of the document "
+        "or the document is owned by an organization and the user has permission to act on behalf "
+        "of that organization.",
+        responses={
+            (status.HTTP_200_OK, "application/json"): OpenApiResponse(
+                response=DocumentSerializer,
+                description="The document was found and its contents are returned as JSON.",
+            ),
+            (status.HTTP_400_BAD_REQUEST, "application/json"): _base_400_response(),
+            status.HTTP_401_UNAUTHORIZED: _base_401_response(),
+            status.HTTP_403_FORBIDDEN: OpenApiResponse(
+                description="The authenticated user lacks the proper permissions to access the document. "
+                "Depending on the requested document, "
+                "either the user does not belong to the admin group of the service which owns the document, "
+                "the user does not own the document or the user does not have permission to act on behalf "
+                "of the organization which owns the document."
+            ),
+            status.HTTP_404_NOT_FOUND: OpenApiResponse(
+                description="No document was found with `documentId`.",
+            ),
+            status.HTTP_500_INTERNAL_SERVER_ERROR: _base_500_response(),
+        },
+        examples=[example_document, example_error],
+    ),
+    "create": extend_schema(
+        summary="Store a new document and its attachments",
+        description="Store a new document and its attachments.\n\n"
+        "This endpoint supports API key authentication to enable unauthenticated users to store documents. "
+        "Note that if this endpoint is used in such a way, accessing the stored documents later "
+        "will only be possible using the appropriate admin credentials.\n\n"
+        "This endpoint also supports authentication using a Bearer token, similarly to the other endpoints. "
+        "In this case the authenticated user is able to access the stored document normally afterwards.",
+        responses={
+            (status.HTTP_201_CREATED, "application/json"): OpenApiResponse(
+                response=DocumentSerializer,
+                description="The document was created successfully. "
+                "The created document is returned in the response body.",
+            ),
+            (status.HTTP_400_BAD_REQUEST, "application/json"): _base_400_response(),
+            status.HTTP_401_UNAUTHORIZED: _base_401_response(),
+            status.HTTP_403_FORBIDDEN: OpenApiResponse(
+                description="The request contains an organization ID and the currently authenticated user "
+                "does not have permission to act on behalf of that organization."
+            ),
+            status.HTTP_500_INTERNAL_SERVER_ERROR: _base_500_response(),
+        },
+        examples=[example_document, example_error],
+    ),
+    "partial_update": extend_schema(
+        summary="Update an existing document",
+        description="Permission to access the document is checked as follows:\n\n"
+        "* Admin users are allowed access to the document if it was stored using the service they are using "
+        "and whose admins they are.\n"
+        "* Authenticated users are allowed access to the document if they are the owner of the document "
+        "or the document is owned by an organization and the user has permission to act "
+        "on behalf of that organization.\n\n"
+        "The following rules apply:\n"
+        "* Drafts may be modified by the owning user, the owning service's admin or an organization's representative, "
+        "if the document is owned by an organization.\n"
+        "* Non-drafts may be modified by an admin.\n"
+        "* Documents may not be modified if their `lockedAfter` date has passed.",
+        responses={
+            (status.HTTP_200_OK, "application/json"): OpenApiResponse(
+                response=DocumentSerializer,
+                description="The Document was updated successfully. "
+                "The updated contents are returned in the response body.",
+            ),
+            (status.HTTP_400_BAD_REQUEST, "application/json"): _base_400_response(),
+            status.HTTP_401_UNAUTHORIZED: _base_401_response(),
+            status.HTTP_403_FORBIDDEN: OpenApiResponse(
+                description="The authenticated user lacks the proper permissions to access the document. "
+                "Depending on the requested document, "
+                "either the user does not belong to the admin group of the service which owns the document, "
+                "the user does not own the document or the user does not have permission to act on behalf "
+                "of the organization which owns the document."
+            ),
+            status.HTTP_404_NOT_FOUND: OpenApiResponse(
+                description="No document was found with `documentId`.",
+            ),
+            status.HTTP_500_INTERNAL_SERVER_ERROR: _base_500_response(),
+        },
+        examples=[example_document, example_error],
+    ),
+    # TODO: Not implemented yet
+    "destroy": extend_schema(exclude=True),
+    #     summary="Remove an existing document and its attachments",
+    #     description="Permission to access the document is checked as follows:\n"
+    #     "* Authenticated users are allowed access to the document if they are the owner of the document "
+    #     "or the document is owned by an organization and the user has permission to act "
+    #     "on behalf of that organization.\n\n"
+    #     "The following rules apply:\n"
+    #     "* Drafts may be removed by the owning user or an organization's representative, "
+    #     "if the document is owned by an organization. This is possible even if the `lockedAfter` date has passed, "
+    #     "to enable a user to remove expired applications.",
+    #     responses={
+    #         status.HTTP_204_NO_CONTENT: OpenApiResponse(
+    #             description="The specified Document and its attachments were removed successfully",
+    #         ),
+    #         (status.HTTP_400_BAD_REQUEST, "application/json"): _base_400_response(),
+    #         status.HTTP_401_UNAUTHORIZED: _base_401_response(),
+    #         status.HTTP_403_FORBIDDEN: OpenApiResponse(
+    #             description="The authenticated user lacks the proper permissions to access the document. "
+    #             "Depending on the requested document, "
+    #             "either the user does not belong to the admin group of the service which owns the document, "
+    #             "the user does not own the document or the user does not have permission to act on behalf "
+    #             "of the organization which owns the document."
+    #         ),
+    #         status.HTTP_404_NOT_FOUND: OpenApiResponse(
+    #             description="No document was found with `documentId`.",
+    #         ),
+    #         status.HTTP_500_INTERNAL_SERVER_ERROR: _base_500_response(),
+    #     },
+    #     examples=[example_error],
+    # ),
+    # Not implementing
+    "update": extend_schema(exclude=True),
+}

--- a/documents/serializers/attachment.py
+++ b/documents/serializers/attachment.py
@@ -25,7 +25,7 @@ class AttachmentSerializer(serializers.ModelSerializer):
             "href",
         )
 
-    def get_href(self, instance):
+    def get_href(self, instance) -> str:
         if request := self.context.get("request"):
             return request.build_absolute_uri(instance.uri)
 

--- a/requirements.in
+++ b/requirements.in
@@ -8,5 +8,6 @@ django-searchable-encrypted-fields
 djangorestframework
 djangorestframework-api-key
 drf-extensions
+drf-spectacular
 psycopg2
 sentry_sdk

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,8 @@
 #
 asgiref==3.4.1
     # via django
+attrs==21.2.0
+    # via jsonschema
 cachetools==4.2.2
     # via django-helusers
 certifi==2021.5.30
@@ -25,6 +27,7 @@ django==3.2.6
     #   django-helusers
     #   django-searchable-encrypted-fields
     #   djangorestframework
+    #   drf-spectacular
 django-cors-headers==3.7.0
     # via -r requirements.in
 django-environ==0.4.5
@@ -41,14 +44,21 @@ djangorestframework==3.12.4
     # via
     #   -r requirements.in
     #   drf-extensions
+    #   drf-spectacular
 djangorestframework-api-key==2.0.0
     # via -r requirements.in
 drf-extensions==0.7.1
+    # via -r requirements.in
+drf-spectacular==0.18.1
     # via -r requirements.in
 ecdsa==0.17.0
     # via python-jose
 idna==3.2
     # via requests
+inflection==0.5.1
+    # via drf-spectacular
+jsonschema==3.2.0
+    # via drf-spectacular
 packaging==21.0
     # via deprecation
 psycopg2==2.9.1
@@ -61,10 +71,14 @@ pycryptodome==3.10.1
     # via django-searchable-encrypted-fields
 pyparsing==2.4.7
     # via packaging
+pyrsistent==0.18.0
+    # via jsonschema
 python-jose==3.3.0
     # via django-helusers
 pytz==2021.1
     # via django
+pyyaml==5.4.1
+    # via drf-spectacular
 requests==2.26.0
     # via django-helusers
 rsa==4.7.2
@@ -72,10 +86,17 @@ rsa==4.7.2
 sentry-sdk==1.3.1
     # via -r requirements.in
 six==1.16.0
-    # via ecdsa
+    # via
+    #   ecdsa
+    #   jsonschema
 sqlparse==0.4.1
     # via django
+uritemplate==3.0.1
+    # via drf-spectacular
 urllib3==1.26.6
     # via
     #   requests
     #   sentry-sdk
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools


### PR DESCRIPTION
## Description :sparkles:
* Add documentation for the existing functionality on the API

## Issues :bug:
### Closes :no_good_woman:
**[ATV-68](https://helsinkisolutionoffice.atlassian.net/browse/ATV-68):** Add swagger documentation for live environment

## Testing :alembic:
### Manual testing :construction_worker_man:
Open the API url:
http://localhost:8000/v1/schema/swagger-ui/#/

## Screenshots :camera_flash:
<img width="1742" alt="image" src="https://user-images.githubusercontent.com/15201480/132636491-06eab35d-d708-43a3-bad9-a79216d63097.png">
<img width="1502" alt="image" src="https://user-images.githubusercontent.com/15201480/132636554-a5274267-698b-40a6-9d23-cfc481f4e717.png">


## Additional notes :spiral_notepad:
For better control of what's displayed, the `documents/api/docs.py` adds the same documentation as the [original API](https://app.swaggerhub.com/apis/klempine/transactions-storage/v1#/), same error codes and descriptions. The functionalities which are not implemented yet are commented, and the ones that will not be implemented are just excluded.