### PR TITLE
ATV-64 | Add filtering, sorting, and paginating for Documents

### DIFF
--- a/atv/settings.py
+++ b/atv/settings.py
@@ -162,6 +162,11 @@ REST_FRAMEWORK = {
     "DEFAULT_PERMISSION_CLASSES": [
         "rest_framework.permissions.IsAdminUser",
     ],
+    "DEFAULT_FILTER_BACKENDS": [
+        "django_filters.rest_framework.DjangoFilterBackend",
+    ],
+    "DEFAULT_PAGINATION_CLASS": "utils.api.PageNumberPagination",
+    "ORDERING_PARAM": "sort",
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
     "DEFAULT_PARENT_LOOKUP_KWARG_NAME_PREFIX": "",
 }

--- a/documents/api/docs.py
+++ b/documents/api/docs.py
@@ -1,7 +1,9 @@
+from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import (
     extend_schema,
     inline_serializer,
     OpenApiExample,
+    OpenApiParameter,
     OpenApiResponse,
 )
 from rest_framework import serializers, status
@@ -250,6 +252,36 @@ document_viewset_docs = {
         "* Authenticated users may fetch documents owned by an organization by giving the organization's business ID "
         "in the search parameters. In this case the user's permission to act on behalf of the organization "
         "is verified and the results will contain only documents which are owned by the given organization.",
+        parameters=[
+            OpenApiParameter(
+                "status",
+                OpenApiTypes.STR,
+                description="Search for documents with the given status",
+            ),
+            OpenApiParameter(
+                "type",
+                OpenApiTypes.STR,
+                description="Search for documents with the given type",
+            ),
+            OpenApiParameter(
+                "business_id",
+                OpenApiTypes.STR,
+                description="Search for documents which are owned by the given business ID. "
+                "If this is given, the calling user must either be an admin or have permission to act "
+                "on behalf of the organization",
+            ),
+            OpenApiParameter(
+                "user_id",
+                OpenApiTypes.UUID,
+                description="Search for documents which are owned by the given user ID. "
+                "If this is given, the calling user must be an admin of the service",
+            ),
+            OpenApiParameter(
+                "transaction_id",
+                OpenApiTypes.STR,
+                description="Search for documents with the given transaction id",
+            ),
+        ],
         responses={
             (status.HTTP_200_OK, "application/json"): OpenApiResponse(
                 response=DocumentSerializer,

--- a/documents/api/filtersets.py
+++ b/documents/api/filtersets.py
@@ -1,0 +1,28 @@
+from django_filters import rest_framework as filters
+
+from ..models import Document
+
+
+class DocumentFilterSet(filters.FilterSet):
+    user_id = filters.UUIDFilter(field_name="user__uuid")
+    created_before = filters.DateFilter(
+        field_name="created_at", lookup_expr="lt", label="Created before"
+    )
+    created_after = filters.DateFilter(
+        field_name="created_at", lookup_expr="gt", label="Created after"
+    )
+    updated_before = filters.DateFilter(
+        field_name="updated_at", lookup_expr="lt", label="Updated before"
+    )
+    updated_after = filters.DateFilter(
+        field_name="updated_at", lookup_expr="gt", label="Updated after"
+    )
+
+    class Meta:
+        model = Document
+        fields = [
+            "status",
+            "type",
+            "business_id",
+            "transaction_id",
+        ]

--- a/documents/api/viewsets.py
+++ b/documents/api/viewsets.py
@@ -29,6 +29,8 @@ from .filtersets import DocumentFilterSet
 class AttachmentViewSet(ModelViewSet, NestedViewSetMixin):
     permission_classes = [IsAdminUser]
     serializer_class = AttachmentSerializer
+    filter_backends = [filters.OrderingFilter]
+    ordering = ["-updated_at", "id"]
 
     def get_queryset(self):
         """

--- a/documents/api/viewsets.py
+++ b/documents/api/viewsets.py
@@ -1,7 +1,8 @@
 from django.db import transaction
 from django.utils.translation import gettext_lazy as _
+from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema, extend_schema_view
-from rest_framework import status
+from rest_framework import filters, status
 from rest_framework.exceptions import MethodNotAllowed, NotFound, PermissionDenied
 from rest_framework.parsers import MultiPartParser
 from rest_framework.permissions import AllowAny, IsAdminUser
@@ -21,6 +22,7 @@ from ..serializers import (
     DocumentSerializer,
 )
 from .docs import attachment_viewset_docs, document_viewset_docs
+from .filtersets import DocumentFilterSet
 
 
 @extend_schema_view(**attachment_viewset_docs)
@@ -50,20 +52,20 @@ class AttachmentViewSet(ModelViewSet, NestedViewSetMixin):
         if user.is_anonymous:
             return Attachment.objects.none()
 
-        filters = {}
+        qs_filters = {}
 
         # Filter the Documents only for the user's Service
         if service := self.request.service:
-            filters["document__service"] = service
+            qs_filters["document__service"] = service
 
         # If the user doesn't have permissions to view that Service,
         # only show the Documents that belong to them
         if not user.has_perm(
-            ServicePermissions.VIEW_ATTACHMENTS.value, filters.get("service")
+            ServicePermissions.VIEW_ATTACHMENTS.value, qs_filters.get("service")
         ):
-            filters = {"document__user_id": user.id}
+            qs_filters = {"document__user_id": user.id}
 
-        return Attachment.objects.filter(**filters)
+        return Attachment.objects.filter(**qs_filters)
 
     def retrieve(self, request, *args, **kwargs):
         raise MethodNotAllowed(request.method)
@@ -81,6 +83,16 @@ class DocumentViewSet(ModelViewSet):
     serializer_class = DocumentSerializer
     # Permission checking is done by the decorators on a method basis
     permission_classes = [AllowAny]
+    # Filtering/sorting
+    filter_backends = [
+        DjangoFilterBackend,
+        filters.OrderingFilter,
+        filters.SearchFilter,
+    ]
+    ordering_fields = ["created_at", "updated_at"]
+    ordering = ["-updated_at"]
+    search_fields = ["metadata"]
+    filterset_class = DocumentFilterSet
 
     def get_queryset(self):
         """
@@ -103,20 +115,20 @@ class DocumentViewSet(ModelViewSet):
         if user.is_anonymous:
             return Document.objects.none()
 
-        filters = {}
+        qs_filters = {}
 
         # Filter the Documents only for the user's Service
         if service := self.request.service:
-            filters["service"] = service
+            qs_filters["service"] = service
 
         # If the user doesn't have permissions to view that Service,
         # only show the Documents that belong to them
         if not user.has_perm(
-            ServicePermissions.VIEW_DOCUMENTS.value, filters.get("service")
+            ServicePermissions.VIEW_DOCUMENTS.value, qs_filters.get("service")
         ):
-            filters = {"user_id": user.id}
+            qs_filters = {"user_id": user.id}
 
-        return Document.objects.filter(**filters)
+        return Document.objects.filter(**qs_filters)
 
     @staff_required(required_permission=ServicePermissions.VIEW_DOCUMENTS)
     def list(self, request, *args, **kwargs):

--- a/documents/tests/snapshots/snap_test_api_create_document.py
+++ b/documents/tests/snapshots/snap_test_api_create_document.py
@@ -7,26 +7,6 @@ from snapshottest import Snapshot
 snapshots = Snapshot()
 
 snapshots["test_create_document 1"] = {
-    "attachments": [
-        {
-            "created_at": "2021-06-30T12:00:00+03:00",
-            "filename": "document2.pdf",
-            "href": "http://testserver/v1/documents/2d2b7a36-a306-4e35-990f-13aea04263ff/attachments/2/",
-            "id": 2,
-            "media_type": "application/pdf",
-            "size": 12,
-            "updated_at": "2021-06-30T12:00:00+03:00",
-        },
-        {
-            "created_at": "2021-06-30T12:00:00+03:00",
-            "filename": "document1.pdf",
-            "href": "http://testserver/v1/documents/2d2b7a36-a306-4e35-990f-13aea04263ff/attachments/1/",
-            "id": 1,
-            "media_type": "application/pdf",
-            "size": 12,
-            "updated_at": "2021-06-30T12:00:00+03:00",
-        },
-    ],
     "business_id": "1234567-8",
     "content": {
         "formData": {
@@ -38,7 +18,6 @@ snapshots["test_create_document 1"] = {
     },
     "created_at": "2021-06-30T12:00:00+03:00",
     "draft": False,
-    "id": "2d2b7a36-a306-4e35-990f-13aea04263ff",
     "locked_after": None,
     "metadata": {"created_by": "alex", "testing": True},
     "status": "handled",

--- a/documents/tests/test_api_list_documents.py
+++ b/documents/tests/test_api_list_documents.py
@@ -1,3 +1,6 @@
+import freezegun
+import pytest
+from dateutil.parser import isoparse
 from guardian.shortcuts import assign_perm
 from rest_framework import status
 from rest_framework.reverse import reverse
@@ -27,9 +30,12 @@ def test_list_document_service_user(api_client, user):
 
     body = response.json()
 
+    results = body.get("results", [])
+
     # The user should only be able to see the one document from the service 1
-    assert len(body) == 1
-    assert body[0].get("id") == expected_document_id
+    assert body.get("count") == 1
+    assert len(results) == 1
+    assert results[0].get("id") == expected_document_id
 
 
 def test_list_document_superuser(api_client, superuser_api_client):
@@ -51,8 +57,11 @@ def test_list_document_superuser(api_client, superuser_api_client):
 
     body = response.json()
 
+    results = body.get("results", [])
+
     # The superuser should be able to see all the documents
-    assert len(body) == 2
+    assert body.get("count") == 2
+    assert len(results) == 2
 
 
 def test_list_document_no_service(api_client, user):
@@ -60,3 +69,130 @@ def test_list_document_no_service(api_client, user):
     response = api_client.get(reverse("documents-list"))
 
     assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.parametrize(
+    "param,value",
+    [
+        ("status", "processed"),
+        ("type", "application"),
+        ("business_id", "1234567-8"),
+        ("user_id", "65352f2c-7b35-4c0d-8209-1d685f30cce9"),
+        ("transaction_id", "49bee2d108be4a68a79d2e5e85791ec8"),
+    ],
+)
+def test_list_document_filter(superuser_api_client, service, param, value):
+    document = DocumentFactory(
+        service=service,
+        id="ffd80e3d-07d7-42db-ba58-b4c4ede2bc0d",
+        status="processed",
+        type="application",
+        business_id="1234567-8",
+        transaction_id="49bee2d108be4a68a79d2e5e85791ec8",
+        user__uuid="65352f2c-7b35-4c0d-8209-1d685f30cce9",
+    )
+    DocumentFactory(
+        service=service,
+        id="8ce91dde-b7ba-4e20-8dd0-835d2060c9d3",
+        status="pending",
+        type="rejection",
+        business_id="8765432-1",
+        transaction_id="cdf67421223b417c90c23b2a4f830286",
+        user__uuid="66d0bfd0-308c-484d-aa22-301512899ae3",
+    )
+
+    url = f"{reverse('documents-list')}?{param}={value}"
+    response = superuser_api_client.get(url)
+
+    results = response.json().get("results", [])
+
+    assert len(results) == 1
+    body = results[0]
+
+    assert body.get("id") == "ffd80e3d-07d7-42db-ba58-b4c4ede2bc0d" == str(document.id)
+    assert body.get("status") == "processed" == str(document.status)
+    assert body.get("type") == "application" == str(document.type)
+    assert body.get("business_id") == "1234567-8" == str(document.business_id)
+    assert (
+        body.get("transaction_id")
+        == "49bee2d108be4a68a79d2e5e85791ec8"
+        == str(document.transaction_id)
+    )
+    assert (
+        body.get("user_id")
+        == "65352f2c-7b35-4c0d-8209-1d685f30cce9"
+        == str(document.user.uuid)
+    )
+
+
+@pytest.mark.parametrize(
+    "ordering",
+    [
+        "created_at",
+        "-created_at",
+        "updated_at",
+        "-updated_at",
+    ],
+)
+def test_list_document_sorting(superuser_api_client, ordering):
+    with freezegun.freeze_time("2021-01-30T12:00:00+03:00"):
+        DocumentFactory()
+
+    with freezegun.freeze_time("2021-06-30T12:00:00+03:00"):
+        DocumentFactory()
+
+    url = f"{reverse('documents-list')}?sort={ordering}"
+    response = superuser_api_client.get(url)
+
+    results = response.json().get("results", [])
+
+    assert len(results) == 2
+
+    document_1 = results[0]
+    document_2 = results[1]
+
+    if ordering == "created_at":
+        assert isoparse(document_1.get("created_at")) < isoparse(
+            document_2.get("created_at")
+        )
+    elif ordering == "-created_at":
+        assert isoparse(document_2.get("created_at")) < isoparse(
+            document_1.get("created_at")
+        )
+    if ordering == "updated_at":
+        assert isoparse(document_1.get("updated_at")) < isoparse(
+            document_2.get("updated_at")
+        )
+    elif ordering == "-updated_at":
+        assert isoparse(document_2.get("updated_at")) < isoparse(
+            document_1.get("updated_at")
+        )
+
+
+@pytest.mark.parametrize(
+    "filter_field,field,expected",
+    [
+        ("created_before", "created_at", "2021-01-30T12:00:00+03:00"),
+        ("created_after", "created_at", "2021-06-30T12:00:00+03:00"),
+        ("updated_before", "updated_at", "2021-01-30T12:00:00+03:00"),
+        ("updated_after", "updated_at", "2021-06-30T12:00:00+03:00"),
+    ],
+)
+def test_list_document_filter_created_at_range(
+    superuser_api_client, filter_field, field, expected
+):
+    with freezegun.freeze_time("2021-01-30T12:00:00+03:00"):
+        DocumentFactory()
+
+    with freezegun.freeze_time("2021-06-30T12:00:00+03:00"):
+        DocumentFactory()
+
+    url = f"{reverse('documents-list')}?{filter_field}=2021-03-01"
+    response = superuser_api_client.get(url)
+
+    results = response.json().get("results", [])
+
+    assert len(results) == 1
+
+    document = results[0]
+    assert isoparse(document.get(field)) == isoparse(expected)

--- a/utils/api.py
+++ b/utils/api.py
@@ -1,0 +1,7 @@
+from rest_framework.pagination import PageNumberPagination as DRFPageNumberPagination
+
+
+class PageNumberPagination(DRFPageNumberPagination):
+    page_size = 20
+    page_size_query_param = "page_size"
+    max_page_size = 100


### PR DESCRIPTION
## Description :sparkles:
* Add filter options by `status`, `type`, `businessId`, `userId`, and `transactionId`
* Add a search option for `metadata` contents
* Allow sorting the results by `created_at` and `updated_at`

The full spec of the API can be found here: https://app.swaggerhub.com/apis/klempine/transactions-storage/v1#/default/get_documents

## Issues :bug:
### Closes :no_good_woman:
**[ATV-64](https://helsinkisolutionoffice.atlassian.net/browse/ATV-64):** Add filter/sorting options for Document list

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest documents/tests/test_api_list_documents.py::test_list_document_filter
$ pytest documents/tests/test_api_list_documents.py::test_list_document_sorting
```

### Manual testing :construction_worker_man:
According to the Documents you have on your environment, try either of the filter parameters as query params, e.g.
```
http://localhost:8000/v1/documents/?type=application
```

## Additional notes :spiral_notepad:
From the original documentation, the `fields` option was left out, at least from the MVP, since we considered it doesn't really add any value, as the clients can just filter the fields they require on their end.