### PR TITLE
ATV-51 | Add audit logging to ModelViewSets

### DIFF
--- a/atv/exceptions.py
+++ b/atv/exceptions.py
@@ -22,7 +22,7 @@ class ValidationError(serializers.ValidationError):
         elif not isinstance(detail, dict) and not isinstance(detail, list):
             detail = {"errors": [detail]}
 
-        super(ValidationError, self).__init__(detail, code)
+        super().__init__(detail, code)
 
 
 def sentry_before_send(event, hint):

--- a/documents/api/viewsets.py
+++ b/documents/api/viewsets.py
@@ -134,7 +134,7 @@ class DocumentViewSet(ModelViewSet):
 
     @staff_required(required_permission=ServicePermissions.VIEW_DOCUMENTS)
     def list(self, request, *args, **kwargs):
-        return super(DocumentViewSet, self).list(request, *args, **kwargs)
+        return super().list(request, *args, **kwargs)
 
     @transaction.atomic()
     @service_api_key_required()
@@ -195,7 +195,7 @@ class DocumentViewSet(ModelViewSet):
             attachment_serializer.is_valid(raise_exception=True)
             attachment_serializer.save()
 
-        return super(DocumentViewSet, self).partial_update(request, pk, *args, **kwargs)
+        return super().partial_update(request, pk, *args, **kwargs)
 
     def update(self, request, *args, **kwargs):
         # Only allow for PATCH updates as described by the documentation
@@ -203,4 +203,4 @@ class DocumentViewSet(ModelViewSet):
         if request.method != "PATCH":
             raise MethodNotAllowed(request.method)
 
-        return super(DocumentViewSet, self).update(request, *args, **kwargs)
+        return super().update(request, *args, **kwargs)

--- a/documents/models.py
+++ b/documents/models.py
@@ -70,7 +70,7 @@ class Attachment(TimestampedModel):
 
         self.full_clean()
 
-        super(Attachment, self).save(*args, **kwargs)
+        super().save(*args, **kwargs)
 
 
 class Document(UUIDModel, TimestampedModel):

--- a/documents/serializers/document.py
+++ b/documents/serializers/document.py
@@ -48,7 +48,7 @@ class DocumentSerializer(serializers.ModelSerializer):
                 _("Cannot update a Document after it has been locked")
             )
 
-        return super(DocumentSerializer, self).update(document, validated_data)
+        return super().update(document, validated_data)
 
 
 class CreateAnonymousDocumentSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
## Description :sparkles:

Add audit logging for `AttachmentViewSet` and `DocumentViewSet`.

## Issues :bug:
### Closes :no_good_woman:
**[ATV-51](https://helsinkisolutionoffice.atlassian.net/browse/ATV-51):** Implement Audit Logging

## Additional notes :spiral_notepad:

Requires #18 
