### PR TITLE
ATV-62 | Add staff checks for attachments

### DIFF
--- a/documents/api/viewsets.py
+++ b/documents/api/viewsets.py
@@ -5,7 +5,7 @@ from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework import filters, status
 from rest_framework.exceptions import MethodNotAllowed, NotFound, PermissionDenied
 from rest_framework.parsers import MultiPartParser
-from rest_framework.permissions import AllowAny, IsAdminUser
+from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework_extensions.mixins import NestedViewSetMixin
 
@@ -27,7 +27,7 @@ from .filtersets import DocumentFilterSet
 
 @extend_schema_view(**attachment_viewset_docs)
 class AttachmentViewSet(AuditLoggingModelViewSet, NestedViewSetMixin):
-    permission_classes = [IsAdminUser]
+    permission_classes = [AllowAny]
     serializer_class = AttachmentSerializer
     filter_backends = [filters.OrderingFilter]
     ordering = ["-updated_at", "id"]
@@ -69,8 +69,9 @@ class AttachmentViewSet(AuditLoggingModelViewSet, NestedViewSetMixin):
 
         return Attachment.objects.filter(**qs_filters)
 
-    def retrieve(self, request, *args, **kwargs):
-        raise MethodNotAllowed(request.method)
+    @staff_required(required_permission=ServicePermissions.VIEW_ATTACHMENTS)
+    def retrieve(self, request, pk, *args, **kwargs):
+        return super(AttachmentViewSet, self).retrieve(request, *args, **kwargs)
 
     def partial_update(self, request, *args, **kwargs):
         raise MethodNotAllowed(request.method)

--- a/documents/tests/conftest.py
+++ b/documents/tests/conftest.py
@@ -7,7 +7,7 @@ from atv.tests.conftest import *  # noqa
 from services.tests.conftest import *  # noqa
 from users.tests.conftest import *  # noqa
 
-from .factories import DocumentFactory
+from .factories import AttachmentFactory, DocumentFactory
 
 
 @pytest.fixture(autouse=True)
@@ -22,3 +22,4 @@ def custom_media_dir_for_files(settings, request):
 
 
 register(DocumentFactory)
+register(AttachmentFactory)

--- a/documents/tests/factories.py
+++ b/documents/tests/factories.py
@@ -5,7 +5,7 @@ import factory
 from services.tests.factories import ServiceFactory
 from users.tests.factories import UserFactory
 
-from ..models import Document
+from ..models import Attachment, Document
 
 
 class DocumentFactory(factory.django.DjangoModelFactory):
@@ -17,3 +17,12 @@ class DocumentFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = Document
+
+
+class AttachmentFactory(factory.django.DjangoModelFactory):
+    document = factory.SubFactory(DocumentFactory)
+    media_type = "application/pdf"
+    file = factory.django.FileField(filename="document.pdf")
+
+    class Meta:
+        model = Attachment

--- a/documents/tests/test_api_attachment_detail.py
+++ b/documents/tests/test_api_attachment_detail.py
@@ -1,0 +1,55 @@
+from guardian.shortcuts import assign_perm
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+from atv.tests.factories import GroupFactory
+from documents.tests.factories import AttachmentFactory
+from services.enums import ServicePermissions
+
+
+def test_attachment_detail_service_user(api_client, user, attachment):
+    group = GroupFactory(name=attachment.document.service.name)
+    user.groups.add(group)
+    assign_perm(
+        ServicePermissions.VIEW_ATTACHMENTS.value, group, attachment.document.service
+    )
+
+    api_client.force_login(user=user)
+    response = api_client.get(
+        reverse(
+            "documents-attachments-detail", args=[attachment.document.id, attachment.id]
+        )
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+    body = response.json()
+
+    # The user should be able to see the attachment from the document
+    assert body.get("id") == attachment.id
+
+
+def test_attachment_detail_superuser(superuser_api_client, document):
+    attachment = AttachmentFactory(document=document)
+
+    response = superuser_api_client.get(
+        reverse("documents-attachments-detail", args=[document.id, attachment.id])
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+    body = response.json()
+
+    # The user should be able to see the attachment from the document
+    assert body.get("id") == attachment.id
+
+
+def test_attachment_detail_no_service(api_client, user, attachment):
+    api_client.force_login(user=user)
+    response = api_client.get(
+        reverse(
+            "documents-attachments-detail", args=[attachment.document.id, attachment.id]
+        )
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/documents/tests/test_api_create_document.py
+++ b/documents/tests/test_api_create_document.py
@@ -58,6 +58,8 @@ def test_create_document(service_api_client, snapshot):
 
     document = Document.objects.first()
     assert document.attachments.count() == 2
+    attachment1 = document.attachments.first()
+    attachment2 = document.attachments.last()
 
     body = response.json()
     assert uuid.UUID(body.pop("id")) == document.id
@@ -65,8 +67,8 @@ def test_create_document(service_api_client, snapshot):
         {
             "created_at": "2021-06-30T12:00:00+03:00",
             "filename": "document2.pdf",
-            "href": f"http://testserver/v1/documents/{document.id}/attachments/2/",
-            "id": 2,
+            "href": f"http://testserver/v1/documents/{document.id}/attachments/{attachment2.id}/",
+            "id": attachment2.id,
             "media_type": "application/pdf",
             "size": 12,
             "updated_at": "2021-06-30T12:00:00+03:00",
@@ -74,8 +76,8 @@ def test_create_document(service_api_client, snapshot):
         {
             "created_at": "2021-06-30T12:00:00+03:00",
             "filename": "document1.pdf",
-            "href": f"http://testserver/v1/documents/{document.id}/attachments/1/",
-            "id": 1,
+            "href": f"http://testserver/v1/documents/{document.id}/attachments/{attachment1.id}/",
+            "id": attachment1.id,
             "media_type": "application/pdf",
             "size": 12,
             "updated_at": "2021-06-30T12:00:00+03:00",

--- a/documents/tests/test_api_list_documents.py
+++ b/documents/tests/test_api_list_documents.py
@@ -39,7 +39,7 @@ def test_list_document_service_user(api_client, user):
     assert results[0].get("id") == expected_document_id
 
 
-def test_list_document_superuser(api_client, superuser_api_client):
+def test_list_document_superuser(superuser_api_client):
     service1 = ServiceFactory(name="service-1")
     service2 = ServiceFactory(name="service-2")
 


### PR DESCRIPTION
## Description :sparkles:
* Add staff checks for attachments

## Issues :bug:
### Closes :no_good_woman:
**[ATV-62](https://helsinkisolutionoffice.atlassian.net/browse/ATV-62):** Add the permission checking for Staff users

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest documents/tests/test_api_attachment_detail.py
```
