### PR TITLE
ATV-37 | Fetch Documents for authenticated users

### DIFF
--- a/documents/admin.py
+++ b/documents/admin.py
@@ -9,7 +9,14 @@ from utils.files import b_to_mb
 
 @admin.register(Document)
 class DocumentAdmin(admin.ModelAdmin):
-    list_display = ("pk", "get_service_name", "draft", "created_at", "updated_at")
+    list_display = (
+        "pk",
+        "get_service_name",
+        "user",
+        "draft",
+        "created_at",
+        "updated_at",
+    )
     search_fields = ("service__name", "type", "status", "business_id")
     list_filter = ("draft",)
     autocomplete_fields = ("service", "user")

--- a/documents/api/viewsets.py
+++ b/documents/api/viewsets.py
@@ -10,7 +10,7 @@ from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
 from rest_framework_extensions.mixins import NestedViewSetMixin
 
-from atv.decorators import login_required, service_api_key_required, staff_required
+from atv.decorators import login_required, service_api_key_required
 from atv.exceptions import ValidationError
 from services.enums import ServicePermissions
 
@@ -132,7 +132,7 @@ class DocumentViewSet(ModelViewSet):
 
         return Document.objects.filter(**qs_filters)
 
-    @staff_required(required_permission=ServicePermissions.VIEW_DOCUMENTS)
+    @login_required()
     def list(self, request, *args, **kwargs):
         return super(DocumentViewSet, self).list(request, *args, **kwargs)
 

--- a/users/models.py
+++ b/users/models.py
@@ -3,3 +3,6 @@ from helusers.models import AbstractUser
 
 class User(AbstractUser):
     audit_log_id_field = "uuid"
+
+    def __str__(self):
+        return f"{self.id} ({self.email or self.username or '-'})"


### PR DESCRIPTION
## Description :sparkles:
* Allow for authenticated users to fetch their own documents
  * The filter for allowed Docuemnts is done on the `get_queryset` level, so when the `list` method is called, it only allows for the specific subset of Documents plus the `login_required`
* Add small tweaks to Django Admin to make it easier which user is associated to a lease

## Issues :bug:
### Closes :no_good_woman:
**[ATV-37](https://helsinkisolutionoffice.atlassian.net/browse/ATV-37):** As an authenticated user I want to filter and sort my diploma copy requests to find a specific request easily

### Related :handshake:
* https://helsinkisolutionoffice.atlassian.net/browse/ATV-36
* #15 
* #20 
