### PR TITLE
ATV-19 | Create authenticated Documents

### DIFF
--- a/documents/tests/snapshots/snap_test_api_create_document.py
+++ b/documents/tests/snapshots/snap_test_api_create_document.py
@@ -6,6 +6,52 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
+snapshots["test_create_anonymous_document 1"] = {
+    "business_id": "1234567-8",
+    "content": {
+        "formData": {
+            "birthDate": "3.11.1957",
+            "firstName": "Dolph",
+            "lastName": "Lundgren",
+        },
+        "reasonForApplication": "No reason, just testing",
+    },
+    "created_at": "2021-06-30T12:00:00+03:00",
+    "draft": False,
+    "locked_after": None,
+    "metadata": {"created_by": "alex", "testing": True},
+    "status": "handled",
+    "tos_function_id": "f917d43aab76420bb2ec53f6684da7f7",
+    "tos_record_id": "89837a682b5d410e861f8f3688154163",
+    "transaction_id": "cf0a341b-6bfd-4f59-8d7c-87bf62ba837b",
+    "type": "mysterious form",
+    "updated_at": "2021-06-30T12:00:00+03:00",
+    "user_id": None,
+}
+
+snapshots["test_create_authenticated_document 1"] = {
+    "attachments": [],
+    "business_id": "1234567-8",
+    "content": {
+        "formData": {
+            "birthDate": "3.11.1957",
+            "firstName": "Dolph",
+            "lastName": "Lundgren",
+        },
+        "reasonForApplication": "No reason, just testing",
+    },
+    "created_at": "2021-06-30T12:00:00+03:00",
+    "draft": False,
+    "locked_after": None,
+    "metadata": {"created_by": "alex", "testing": True},
+    "status": "handled",
+    "tos_function_id": "f917d43aab76420bb2ec53f6684da7f7",
+    "tos_record_id": "89837a682b5d410e861f8f3688154163",
+    "transaction_id": "cf0a341b-6bfd-4f59-8d7c-87bf62ba837b",
+    "type": "mysterious form",
+    "updated_at": "2021-06-30T12:00:00+03:00",
+}
+
 snapshots["test_create_document 1"] = {
     "business_id": "1234567-8",
     "content": {

--- a/services/utils.py
+++ b/services/utils.py
@@ -1,0 +1,28 @@
+from django.conf import settings
+from rest_framework.exceptions import NotAuthenticated
+
+from atv.exceptions import MissingServiceAPIKey
+
+from .models import Service, ServiceAPIKey
+
+
+def get_service_from_service_key(request, raise_exception: bool = True) -> Service:
+    key = request.META.get(settings.API_KEY_CUSTOM_HEADER)
+    service = None
+
+    try:
+        if not key:
+            raise MissingServiceAPIKey()
+
+        # get_from_key also checks that the key is still valid
+        service_key = ServiceAPIKey.objects.get_from_key(key)
+        service = service_key.service
+    except (
+        ServiceAPIKey.DoesNotExist,
+        Service.DoesNotExist,
+        MissingServiceAPIKey,
+    ):
+        if raise_exception:
+            raise NotAuthenticated()
+
+    return service


### PR DESCRIPTION
## Description :sparkles:
* Modify `DocumentViewSet` to allow creating authenticated Documents
  * When the user is not authenticated, it tries creating the document anonymously with the Service API key. If no key is found, then a 403 status is returned

## Issues :bug:
### Closes :no_good_woman:
**[ATV-19](https://helsinkisolutionoffice.atlassian.net/browse/ATV-19):** As an authenticated user I want to submit a diploma copy request, to obtain a copy of my diploma

### Related :handshake:
#10 

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest documents/tests/test_api_create_document.py
```

### Manual testing :construction_worker_man:
Testing manually is a bit complex at the moment, since we don't have the JWT authentication in place yet. The way to do it would be to login with a valid user which has been assigned to a permission group for a `Service`, so that the `ServiceMiddleware` can determine the correct Service.

With that user, then send the POST request through the API
```
http://localhost:8000/v1/documents/
```