### PR TITLE
ATV-21 | Authenticated user documents

### DIFF
--- a/documents/api/viewsets.py
+++ b/documents/api/viewsets.py
@@ -10,7 +10,7 @@ from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework_extensions.mixins import NestedViewSetMixin
 
-from atv.decorators import login_required
+from atv.decorators import login_required, service_required
 from atv.exceptions import ValidationError
 from audit_log.viewsets import AuditLoggingModelViewSet
 from services.enums import ServicePermissions
@@ -136,11 +136,12 @@ class DocumentViewSet(AuditLoggingModelViewSet):
         if not user.has_perm(
             ServicePermissions.VIEW_DOCUMENTS.value, qs_filters.get("service")
         ):
-            qs_filters = {"user_id": user.id}
+            qs_filters["user_id"] = user.id
 
         return Document.objects.filter(**qs_filters)
 
     @login_required()
+    @service_required()
     def list(self, request, *args, **kwargs):
         return super().list(request, *args, **kwargs)
 


### PR DESCRIPTION
## Description :sparkles:
* Add better tests for this functionality
* Fix queryset to filter **both** user and service

## Issues :bug:
### Closes :no_good_woman:
**[ATV-21](https://helsinkisolutionoffice.atlassian.net/browse/ATV-21):** As an authenticated user I want to see a list of my diploma copy requests, to see the requests' status and information

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest documents/tests/test_api_list_documents.py
```

## Additional notes :spiral_notepad:
The other two open PRs have to be merged first
#27
#28 