### PR TITLE
ATV-23 | Remove Documents

### DIFF
--- a/atv/exceptions.py
+++ b/atv/exceptions.py
@@ -50,6 +50,13 @@ class DocumentLockedException(APIException):
     default_code = "DOCUMENT_LOCKED"
     default_detail = _("Unable to modify document - it's no longer a draft.")
 
+    def __init__(self, detail=None, code=None, locked_after=None):
+        detail = detail or self.default_detail
+        if locked_after:
+            detail = f"{detail} Locked at: {locked_after}."
+
+        super().__init__(detail=detail, code=code or self.default_code)
+
 
 class InvalidFieldException(APIException):
     status_code = status.HTTP_400_BAD_REQUEST

--- a/documents/api/docs.py
+++ b/documents/api/docs.py
@@ -387,36 +387,36 @@ document_viewset_docs = {
         examples=[example_document, example_error],
     ),
     # TODO: Not implemented yet
-    "destroy": extend_schema(exclude=True),
-    #     summary="Remove an existing document and its attachments",
-    #     description="Permission to access the document is checked as follows:\n"
-    #     "* Authenticated users are allowed access to the document if they are the owner of the document "
-    #     "or the document is owned by an organization and the user has permission to act "
-    #     "on behalf of that organization.\n\n"
-    #     "The following rules apply:\n"
-    #     "* Drafts may be removed by the owning user or an organization's representative, "
-    #     "if the document is owned by an organization. This is possible even if the `lockedAfter` date has passed, "
-    #     "to enable a user to remove expired applications.",
-    #     responses={
-    #         status.HTTP_204_NO_CONTENT: OpenApiResponse(
-    #             description="The specified Document and its attachments were removed successfully",
-    #         ),
-    #         (status.HTTP_400_BAD_REQUEST, "application/json"): _base_400_response(),
-    #         status.HTTP_401_UNAUTHORIZED: _base_401_response(),
-    #         status.HTTP_403_FORBIDDEN: OpenApiResponse(
-    #             description="The authenticated user lacks the proper permissions to access the document. "
-    #             "Depending on the requested document, "
-    #             "either the user does not belong to the admin group of the service which owns the document, "
-    #             "the user does not own the document or the user does not have permission to act on behalf "
-    #             "of the organization which owns the document."
-    #         ),
-    #         status.HTTP_404_NOT_FOUND: OpenApiResponse(
-    #             description="No document was found with `documentId`.",
-    #         ),
-    #         status.HTTP_500_INTERNAL_SERVER_ERROR: _base_500_response(),
-    #     },
-    #     examples=[example_error],
-    # ),
+    "destroy": extend_schema(
+        summary="Remove an existing document and its attachments",
+        description="Permission to access the document is checked as follows:\n"
+        "* Authenticated users are allowed access to the document if they are the owner of the document "
+        "or the document is owned by an organization and the user has permission to act "
+        "on behalf of that organization.\n\n"
+        "The following rules apply:\n"
+        "* Drafts may be removed by the owning user or an organization's representative, "
+        "if the document is owned by an organization. This is possible even if the `lockedAfter` date has passed, "
+        "to enable a user to remove expired applications.",
+        responses={
+            status.HTTP_204_NO_CONTENT: OpenApiResponse(
+                description="The specified Document and its attachments were removed successfully",
+            ),
+            (status.HTTP_400_BAD_REQUEST, "application/json"): _base_400_response(),
+            status.HTTP_401_UNAUTHORIZED: _base_401_response(),
+            status.HTTP_403_FORBIDDEN: OpenApiResponse(
+                description="The authenticated user lacks the proper permissions to access the document. "
+                "Depending on the requested document, "
+                "either the user does not belong to the admin group of the service which owns the document, "
+                "the user does not own the document or the user does not have permission to act on behalf "
+                "of the organization which owns the document."
+            ),
+            status.HTTP_404_NOT_FOUND: OpenApiResponse(
+                description="No document was found with `documentId`.",
+            ),
+            status.HTTP_500_INTERNAL_SERVER_ERROR: _base_500_response(),
+        },
+        examples=[example_error],
+    ),
     # Not implementing
     "update": extend_schema(exclude=True),
 }

--- a/documents/tests/test_api_destroy_document.py
+++ b/documents/tests/test_api_destroy_document.py
@@ -1,0 +1,229 @@
+from datetime import timezone
+from uuid import uuid4
+
+from dateutil.relativedelta import relativedelta
+from dateutil.utils import today
+from freezegun import freeze_time
+from guardian.shortcuts import assign_perm
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+from atv.tests.factories import GroupFactory
+from audit_log.models import AuditLogEntry
+from documents.models import Document
+from documents.tests.factories import DocumentFactory
+from services.enums import ServicePermissions
+from services.tests.utils import get_user_service_client
+from utils.exceptions import get_error_response
+
+# OWNER-RELATED ACTIONS
+
+
+@freeze_time("2021-06-30T12:00:00+03:00")
+def test_destroy_document_owner(user, service):
+    api_client = get_user_service_client(user, service)
+
+    document = DocumentFactory(
+        draft=True,
+        user=user,
+        service=service,
+    )
+    assert Document.objects.count() == 1
+
+    response = api_client.delete(reverse("documents-detail", args=[document.id]))
+
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    assert Document.objects.count() == 0
+
+
+@freeze_time("2021-06-30T12:00:00+03:00")
+def test_destroy_document_owner_someone_elses_document(user, service):
+    api_client = get_user_service_client(user, service)
+
+    document = DocumentFactory(
+        draft=True,
+        service=service,
+    )
+    assert Document.objects.count() == 1
+
+    # Check that the owner of the document is different than the one
+    # making the request
+    assert document.user != user
+
+    response = api_client.delete(reverse("documents-detail", args=[document.id]))
+
+    body = response.json()
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert body == get_error_response(
+        "NOT_FOUND",
+        "No Document matches the given query.",
+    )
+
+
+@freeze_time("2021-06-30T12:00:00+03:00")
+def test_destroy_document_owner_non_draft(user, service):
+    api_client = get_user_service_client(user, service)
+
+    document = DocumentFactory(
+        draft=False,
+        user=user,
+        service=service,
+    )
+
+    response = api_client.delete(reverse("documents-detail", args=[document.id]))
+
+    body = response.json()
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert body == get_error_response(
+        "DOCUMENT_LOCKED",
+        "Unable to modify document - it's no longer a draft.",
+    )
+
+
+@freeze_time("2021-06-30T12:00:00")
+def test_destroy_document_owner_after_lock_date(user, service):
+    api_client = get_user_service_client(user, service)
+
+    document = DocumentFactory(
+        locked_after=today(timezone.utc) - relativedelta(days=1),
+        draft=True,
+        user=user,
+        service=service,
+    )
+
+    response = api_client.delete(reverse("documents-detail", args=[document.id]))
+
+    body = response.json()
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert body == get_error_response(
+        "DOCUMENT_LOCKED",
+        f"Unable to modify document - it's no longer a draft. Locked at: {document.locked_after}.",
+    )
+
+
+# STAFF-RELATED ACTION
+
+
+@freeze_time("2021-06-30T12:00:00+03:00")
+def test_destroy_document_staff(user, service):
+    api_client = get_user_service_client(user, service)
+
+    group = GroupFactory(name=service.name)
+    assign_perm(ServicePermissions.MANAGE_DOCUMENTS.value, group, service)
+    user.groups.add(group)
+
+    document = DocumentFactory(
+        draft=True,
+        service=service,
+    )
+    assert Document.objects.count() == 1
+
+    response = api_client.delete(reverse("documents-detail", args=[document.id]))
+
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    assert Document.objects.count() == 0
+
+
+@freeze_time("2021-06-30T12:00:00+03:00")
+def test_destroy_document_staff_non_draft(user, service):
+    api_client = get_user_service_client(user, service)
+
+    group = GroupFactory(name=service.name)
+    assign_perm(ServicePermissions.MANAGE_DOCUMENTS.value, group, service)
+    user.groups.add(group)
+
+    document = DocumentFactory(
+        service=service,
+        draft=False,
+    )
+
+    assert Document.objects.count() == 1
+
+    response = api_client.delete(reverse("documents-detail", args=[document.id]))
+
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    assert Document.objects.count() == 0
+
+
+@freeze_time("2021-06-30T12:00:00")
+def test_destroy_document_staff_after_lock_date(user, service):
+    api_client = get_user_service_client(user, service)
+
+    group = GroupFactory(name=service.name)
+    assign_perm(ServicePermissions.MANAGE_DOCUMENTS.value, group, service)
+    user.groups.add(group)
+
+    document = DocumentFactory(
+        draft=True,
+        locked_after=today(timezone.utc) - relativedelta(days=1),
+        service=service,
+    )
+
+    assert Document.objects.count() == 1
+
+    response = api_client.delete(reverse("documents-detail", args=[document.id]))
+
+    body = response.json()
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert body == get_error_response(
+        "DOCUMENT_LOCKED",
+        f"Unable to modify document - it's no longer a draft. Locked at: {document.locked_after}.",
+    )
+
+
+@freeze_time("2021-06-30T12:00:00")
+def test_destroy_document_staff_another_service(user, service):
+    api_client = get_user_service_client(user, service)
+
+    group = GroupFactory(name=service.name)
+    assign_perm(ServicePermissions.MANAGE_DOCUMENTS.value, group, service)
+    user.groups.add(group)
+
+    document = DocumentFactory()
+
+    response = api_client.delete(reverse("documents-detail", args=[document.id]))
+
+    body = response.json()
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert body == get_error_response(
+        "NOT_FOUND",
+        "No Document matches the given query.",
+    )
+
+
+# OTHER STUFF
+
+
+@freeze_time("2021-06-30T12:00:00")
+def test_destroy_document_not_found(superuser_api_client):
+    response = superuser_api_client.delete(reverse("documents-detail", args=[uuid4()]))
+
+    body = response.json()
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert body == get_error_response(
+        "NOT_FOUND",
+        "No Document matches the given query.",
+    )
+
+
+def test_audit_log_is_created_when_destroying(user, service):
+    api_client = get_user_service_client(user, service)
+
+    document = DocumentFactory(draft=True, user=user, service=service)
+
+    api_client.delete(reverse("documents-detail", args=[document.id]))
+
+    assert (
+        AuditLogEntry.objects.filter(
+            message__audit_event__target__type="Document",
+            message__audit_event__target__id=str(document.pk),
+            message__audit_event__operation="DELETE",
+        ).count()
+        == 1
+    )


### PR DESCRIPTION
## Description :sparkles:
* Add functionality and checks for deleting documents
* Add `locked_after` details to the error message
* Update the API documentation to match the changes

## Issues :bug:
### Closes :no_good_woman:
**[ATV-21](https://helsinkisolutionoffice.atlassian.net/browse/ATV-21):** 

### Related 🤝 
Requires that the following PR merged first:
#31 

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest documents/tests/test_api_destroy_document.py
```
