### PR TITLE
ATV-25 | Remove Attachment

### DIFF
--- a/documents/api/docs.py
+++ b/documents/api/docs.py
@@ -199,38 +199,38 @@ attachment_viewset_docs = {
     #     examples=[example_attachment, example_error],
     # ),
     # TODO: Not implemented yet
-    "destroy": extend_schema(exclude=True),
-    #     summary="Remove a document's attachment",
-    #     description="Permission to remove the attachment is checked based on the containing document as follows:\n"
-    #     "* Authenticated users are allowed to remove the attachment if they are the owner of the containing document "
-    #     "or the containing document is owned by an organization and the user has permission to act on behalf "
-    #     "of that organization.\n\n"
-    #     "The following rules apply:\n"
-    #     "* Attachments of drafts may be removed by the owning user or an organization's representative, "
-    #     "if the containing document is owned by an organization."
-    #     "* Attachments may not be removed if the containing document's `lockedAfter` date has passed. "
-    #     "This should be done by removing the whole document.",
-    #     responses={
-    #         status.HTTP_204_NO_CONTENT: OpenApiResponse(
-    #             description="The attachment was removed successfully.",
-    #         ),
-    #         (status.HTTP_400_BAD_REQUEST, "application/json"): _base_400_response(),
-    #         status.HTTP_401_UNAUTHORIZED: _base_401_response(),
-    #         status.HTTP_403_FORBIDDEN: OpenApiResponse(
-    #             description="The authenticated user lacks the proper permissions to access the document. "
-    #             "Depending on the requested document, "
-    #             "either the user does not belong to the admin group of the service which owns the document, "
-    #             "the user does not own the document or the user does not have permission to act on behalf "
-    #             "of the organization which owns the document."
-    #         ),
-    #         status.HTTP_404_NOT_FOUND: OpenApiResponse(
-    #             description="No document was found with `documentId` or the document did not have "
-    #             "an attachment `attachmentId`."
-    #         ),
-    #         status.HTTP_500_INTERNAL_SERVER_ERROR: _base_500_response(),
-    #     },
-    #     examples=[example_error],
-    # ),
+    "destroy": extend_schema(
+        summary="Remove a document's attachment",
+        description="Permission to remove the attachment is checked based on the containing document as follows:\n"
+        "* Authenticated users are allowed to remove the attachment if they are the owner of the containing document "
+        "or the containing document is owned by an organization and the user has permission to act on behalf "
+        "of that organization.\n\n"
+        "The following rules apply:\n"
+        "* Attachments of drafts may be removed by the owning user or an organization's representative, "
+        "if the containing document is owned by an organization."
+        "* Attachments may not be removed if the containing document's `lockedAfter` date has passed. "
+        "This should be done by removing the whole document.",
+        responses={
+            status.HTTP_204_NO_CONTENT: OpenApiResponse(
+                description="The attachment was removed successfully.",
+            ),
+            (status.HTTP_400_BAD_REQUEST, "application/json"): _base_400_response(),
+            status.HTTP_401_UNAUTHORIZED: _base_401_response(),
+            status.HTTP_403_FORBIDDEN: OpenApiResponse(
+                description="The authenticated user lacks the proper permissions to access the document. "
+                "Depending on the requested document, "
+                "either the user does not belong to the admin group of the service which owns the document, "
+                "the user does not own the document or the user does not have permission to act on behalf "
+                "of the organization which owns the document."
+            ),
+            status.HTTP_404_NOT_FOUND: OpenApiResponse(
+                description="No document was found with `documentId` or the document did not have "
+                "an attachment `attachmentId`."
+            ),
+            status.HTTP_500_INTERNAL_SERVER_ERROR: _base_500_response(),
+        },
+        examples=[example_error],
+    ),
     # Not implementing
     "list": extend_schema(exclude=True),
     "update": extend_schema(exclude=True),

--- a/documents/tests/test_api_destroy_attachment.py
+++ b/documents/tests/test_api_destroy_attachment.py
@@ -1,0 +1,208 @@
+import random
+from datetime import timezone
+
+from dateutil.relativedelta import relativedelta
+from dateutil.utils import today
+from freezegun import freeze_time
+from guardian.shortcuts import assign_perm
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+from atv.tests.factories import GroupFactory
+from audit_log.models import AuditLogEntry
+from documents.models import Attachment
+from documents.tests.factories import AttachmentFactory
+from services.enums import ServicePermissions
+from services.tests.utils import get_user_service_client
+from utils.exceptions import get_error_response
+
+# OWNER-RELATED ACTIONS
+
+
+@freeze_time("2021-06-30T12:00:00+03:00")
+def test_destroy_attachment_owner(user, service):
+    api_client = get_user_service_client(user, service)
+
+    attachment = AttachmentFactory(
+        document__draft=True,
+        document__user=user,
+        document__service=service,
+    )
+    assert Attachment.objects.count() == 1
+
+    response = api_client.delete(
+        reverse(
+            "documents-attachments-detail",
+            args=[attachment.document.id, attachment.id],
+        )
+    )
+
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    assert Attachment.objects.count() == 0
+
+
+@freeze_time("2021-06-30T12:00:00+03:00")
+def test_destroy_attachment_owner_someone_elses_attachment(user, service):
+    api_client = get_user_service_client(user, service)
+
+    attachment = AttachmentFactory(
+        document__draft=True,
+        document__service=service,
+    )
+    assert Attachment.objects.count() == 1
+
+    # Check that the owner of the document is different than the one
+    # making the request
+    assert attachment.document.user != user
+
+    response = api_client.delete(
+        reverse(
+            "documents-attachments-detail",
+            args=[attachment.document.id, attachment.id],
+        )
+    )
+
+    body = response.json()
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert body == get_error_response(
+        "NOT_FOUND",
+        "No Attachment matches the given query.",
+    )
+
+
+@freeze_time("2021-06-30T12:00:00+03:00")
+def test_destroy_attachment_owner_non_draft(user, service):
+    api_client = get_user_service_client(user, service)
+
+    attachment = AttachmentFactory(
+        document__draft=False,
+        document__user=user,
+        document__service=service,
+    )
+    assert Attachment.objects.count() == 1
+
+    response = api_client.delete(
+        reverse(
+            "documents-attachments-detail",
+            args=[attachment.document.id, attachment.id],
+        )
+    )
+
+    body = response.json()
+
+    assert Attachment.objects.count() == 1
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert body == get_error_response(
+        "DOCUMENT_LOCKED",
+        "Unable to modify document - it's no longer a draft.",
+    )
+
+
+@freeze_time("2021-06-30T12:00:00")
+def test_destroy_attachment_owner_after_lock_date(user, service):
+    api_client = get_user_service_client(user, service)
+
+    attachment = AttachmentFactory(
+        document__locked_after=today(timezone.utc) - relativedelta(days=1),
+        document__draft=True,
+        document__user=user,
+        document__service=service,
+    )
+    assert Attachment.objects.count() == 1
+
+    response = api_client.delete(
+        reverse(
+            "documents-attachments-detail",
+            args=[attachment.document.id, attachment.id],
+        )
+    )
+
+    body = response.json()
+
+    assert Attachment.objects.count() == 1
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert body == get_error_response(
+        "DOCUMENT_LOCKED",
+        f"Unable to modify document - it's no longer a draft. Locked at: {attachment.document.locked_after}.",
+    )
+
+
+# STAFF-RELATED ACTION
+
+
+@freeze_time("2021-06-30T12:00:00+03:00")
+def test_destroy_attachment_staff_no_permissions(user, service):
+    api_client = get_user_service_client(user, service)
+
+    group = GroupFactory(name=service.name)
+    assign_perm(ServicePermissions.MANAGE_ATTACHMENTS.value, group, service)
+    user.groups.add(group)
+
+    attachment = AttachmentFactory(
+        document__service=service,
+    )
+    assert Attachment.objects.count() == 1
+
+    response = api_client.delete(
+        reverse(
+            "documents-attachments-detail",
+            args=[attachment.document.id, attachment.id],
+        )
+    )
+
+    body = response.json()
+
+    assert Attachment.objects.count() == 1
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert body == get_error_response(
+        "PERMISSION_DENIED",
+        "You do not have permission to perform this action.",
+    )
+
+
+# OTHER STUFF
+
+
+@freeze_time("2021-06-30T12:00:00")
+def test_destroy_attachment_not_found(superuser_api_client, document):
+    response = superuser_api_client.delete(
+        reverse(
+            "documents-attachments-detail",
+            args=[document.id, random.randint(0, 100)],
+        )
+    )
+
+    body = response.json()
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert body == get_error_response(
+        "NOT_FOUND",
+        "No Attachment matches the given query.",
+    )
+
+
+def test_audit_log_is_created_when_destroying(user, service):
+    api_client = get_user_service_client(user, service)
+
+    attachment = AttachmentFactory(
+        document__draft=True,
+        document__user=user,
+        document__service=service,
+    )
+
+    api_client.delete(
+        reverse(
+            "documents-attachments-detail",
+            args=[attachment.document.id, attachment.id],
+        )
+    )
+
+    assert (
+        AuditLogEntry.objects.filter(
+            message__audit_event__target__type="Attachment",
+            message__audit_event__target__id=str(attachment.pk),
+            message__audit_event__operation="DELETE",
+        ).count()
+        == 1
+    )


### PR DESCRIPTION
## Description :sparkles:
* Add functionality to remove Attachments
* Update the API documentation to match the changes

## Issues :bug:
### Closes :no_good_woman:
**[ATV-25](https://helsinkisolutionoffice.atlassian.net/browse/ATV-25):** As an authenticated user I want to remove an attachment from my diploma copy request draft to get rid of a wrong attachment

### Related :handshake:
Requires that this PRs are merged first:
#31 
#33 

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest documents/tests/test_api_destroy_attachment.py
```

## Additional notes :spiral_notepad:
* Only owners are allowed to remove them, in this case `staff` can't