### PR TITLE
ATV-26 | Create Attachment for Documents

### DIFF
--- a/atv/exceptions.py
+++ b/atv/exceptions.py
@@ -50,12 +50,12 @@ class MaximumFileSizeExceededException(APIException):
 class DocumentLockedException(APIException):
     status_code = status.HTTP_403_FORBIDDEN
     default_code = "DOCUMENT_LOCKED"
-    default_detail = _("Unable to modify document - it's no longer a draft.")
+    default_detail = _("Unable to modify document - it's no longer a draft")
 
     def __init__(self, detail=None, code=None, locked_after=None):
         detail = detail or self.default_detail
         if locked_after:
-            detail = f"{detail} Locked at: {locked_after}."
+            detail = f"{detail}. Locked at: {locked_after}."
 
         super().__init__(detail=detail, code=code or self.default_code)
 

--- a/atv/exceptions.py
+++ b/atv/exceptions.py
@@ -73,3 +73,16 @@ class InvalidFieldException(APIException):
             detail = f"{detail}: {', '.join(fields)}."
 
         super().__init__(detail=detail, code=code or self.default_code)
+
+
+class MissingParameterException(APIException):
+    status_code = status.HTTP_400_BAD_REQUEST
+    default_code = "MISSING_PARAMETER"
+    default_detail = _("Missing parameter")
+
+    def __init__(self, detail=None, code=None, parameter=None):
+        detail = detail or self.default_detail
+        if parameter:
+            detail = f"{detail}: {parameter}."
+
+        super().__init__(detail=detail, code=code or self.default_code)

--- a/documents/api/docs.py
+++ b/documents/api/docs.py
@@ -8,7 +8,7 @@ from drf_spectacular.utils import (
 )
 from rest_framework import serializers, status
 
-from documents.serializers import DocumentSerializer
+from documents.serializers import AttachmentSerializer, DocumentSerializer
 
 error_serializer = inline_serializer(
     "ErrorResponse",
@@ -167,38 +167,35 @@ attachment_viewset_docs = {
         },
         examples=[example_attachment, example_error],
     ),
-    # TODO: Not implemented yet
-    "create": extend_schema(exclude=True),
-    #     summary="Upload a new attachment to a document",
-    #     description="Permission to access the document is checked as follows:\n"
-    #     "* Authenticated users are allowed access to the document if they are the owner of the document "
-    #     "or the document is owned by an organization and the user has permission to act on behalf "
-    #     "of that organization.\n\n"
-    #     "The following rules apply:\n"
-    #     "* Drafts may be modified by the owning user, "
-    #     "the owning service's admin or an organization's representative, "
-    #     "if the document is owned by an organization.\n"
-    #     "* Non-drafts may be modified by an admin.\n"
-    #     "* Documents may not be modified if their `lockedAfter` date has passed.",
-    #     #     # TODO: Need to add a serializer for plain file
-    #     #     request=None,
-    #     responses={
-    #         (status.HTTP_201_CREATED, "application/json"): OpenApiResponse(
-    #             response=AttachmentSerializer,
-    #             description="The attachment was uploaded successfully. "
-    #             "The attachments information is returned in the response body.",
-    #         ),
-    #         (status.HTTP_400_BAD_REQUEST, "application/json"): _base_400_response(),
-    #         status.HTTP_401_UNAUTHORIZED: _base_401_response(),
-    #         status.HTTP_403_FORBIDDEN: OpenApiResponse(
-    #             description="The request contains an organization ID and the currently authenticated user "
-    #             "does not have permission to act on behalf of that organization."
-    #         ),
-    #         status.HTTP_500_INTERNAL_SERVER_ERROR: _base_500_response(),
-    #     },
-    #     examples=[example_attachment, example_error],
-    # ),
-    # TODO: Not implemented yet
+    "create": extend_schema(
+        summary="Upload a new attachment to a document",
+        description="Permission to access the document is checked as follows:\n"
+        "* Authenticated users are allowed access to the document if they are the owner of the document "
+        "or the document is owned by an organization and the user has permission to act on behalf "
+        "of that organization.\n\n"
+        "The following rules apply:\n"
+        "* Drafts may be modified by the owning user, "
+        "the owning service's admin or an organization's representative, "
+        "if the document is owned by an organization.\n"
+        "* Non-drafts may be modified by an admin.\n"
+        "* Documents may not be modified if their `lockedAfter` date has passed.",
+        request={"application/octet-stream": OpenApiTypes.BINARY},
+        responses={
+            (status.HTTP_201_CREATED, "application/json"): OpenApiResponse(
+                response=AttachmentSerializer,
+                description="The attachment was uploaded successfully. "
+                "The attachments information is returned in the response body.",
+            ),
+            (status.HTTP_400_BAD_REQUEST, "application/json"): _base_400_response(),
+            status.HTTP_401_UNAUTHORIZED: _base_401_response(),
+            status.HTTP_403_FORBIDDEN: OpenApiResponse(
+                description="The request contains an organization ID and the currently authenticated user "
+                "does not have permission to act on behalf of that organization."
+            ),
+            status.HTTP_500_INTERNAL_SERVER_ERROR: _base_500_response(),
+        },
+        examples=[example_attachment, example_error],
+    ),
     "destroy": extend_schema(
         summary="Remove a document's attachment",
         description="Permission to remove the attachment is checked based on the containing document as follows:\n"
@@ -386,7 +383,6 @@ document_viewset_docs = {
         },
         examples=[example_document, example_error],
     ),
-    # TODO: Not implemented yet
     "destroy": extend_schema(
         summary="Remove an existing document and its attachments",
         description="Permission to access the document is checked as follows:\n"

--- a/documents/api/docs.py
+++ b/documents/api/docs.py
@@ -143,9 +143,10 @@ attachment_viewset_docs = {
         description="Permission to access the attachment is checked based on the containing document as follows:\n"
         "* Admin users are allowed access to the attachment if the containing document was stored using the service "
         "they are using and whose admins they are.\n"
-        "* Authenticated users are allowed access to the attachment if they are the owner of the containing document "
-        "or the containing document is owned by an organization and the user has permission to act on behalf "
-        "of that organization.",
+        "* Authenticated users are allowed access to the attachment if they are the owner of the containing document.",
+        # TODO: Uncomment when organization features are implemented
+        # " or the containing document is owned by an organization and the user has permission to act on behalf "
+        # "of that organization.",
         responses={
             (status.HTTP_200_OK, "application/octet-stream"): OpenApiResponse(
                 description="Returns the attachment as a downloadable file.",
@@ -156,8 +157,10 @@ attachment_viewset_docs = {
                 description="The authenticated user lacks the proper permissions to access the document. "
                 "Depending on the requested document, "
                 "either the user does not belong to the admin group of the service which owns the document, "
-                "the user does not own the document or the user does not have permission to act on behalf "
-                "of the organization which owns the document."
+                "the user does not own the document."
+                # TODO: Uncomment when organization features are implemented
+                # " or the user does not have permission to act on behalf "
+                # "of the organization which owns the document."
             ),
             status.HTTP_404_NOT_FOUND: OpenApiResponse(
                 description="No document was found with `documentId` or the document did not have "
@@ -170,13 +173,17 @@ attachment_viewset_docs = {
     "create": extend_schema(
         summary="Upload a new attachment to a document",
         description="Permission to access the document is checked as follows:\n"
-        "* Authenticated users are allowed access to the document if they are the owner of the document "
-        "or the document is owned by an organization and the user has permission to act on behalf "
-        "of that organization.\n\n"
+        "* Authenticated users are allowed access to the document if they are the owner of the document.\n\n"
+        # TODO: Uncomment when organization features are implemented
+        # " or the document is owned by an organization and the user has permission to act on behalf "
+        # "of that organization.\n\n"
         "The following rules apply:\n"
-        "* Drafts may be modified by the owning user, "
-        "the owning service's admin or an organization's representative, "
-        "if the document is owned by an organization.\n"
+        "* Drafts may be modified by the owning user or the owning service's admin\n"
+        # TODO: Uncomment when organization features are implemented
+        #   Replace the previous line with the following
+        # "* Drafts may be modified by the owning user, "
+        # "the owning service's admin or an organization's representative, "
+        # "if the document is owned by an organization.\n"
         "* Non-drafts may be modified by an admin.\n"
         "* Documents may not be modified if their `lockedAfter` date has passed.",
         request={"application/octet-stream": OpenApiTypes.BINARY},
@@ -188,10 +195,11 @@ attachment_viewset_docs = {
             ),
             (status.HTTP_400_BAD_REQUEST, "application/json"): _base_400_response(),
             status.HTTP_401_UNAUTHORIZED: _base_401_response(),
-            status.HTTP_403_FORBIDDEN: OpenApiResponse(
-                description="The request contains an organization ID and the currently authenticated user "
-                "does not have permission to act on behalf of that organization."
-            ),
+            # TODO: Uncomment when organization features are implemented
+            # status.HTTP_403_FORBIDDEN: OpenApiResponse(
+            #     description="The request contains an organization ID and the currently authenticated user "
+            #     "does not have permission to act on behalf of that organization."
+            # ),
             status.HTTP_500_INTERNAL_SERVER_ERROR: _base_500_response(),
         },
         examples=[example_attachment, example_error],
@@ -199,12 +207,16 @@ attachment_viewset_docs = {
     "destroy": extend_schema(
         summary="Remove a document's attachment",
         description="Permission to remove the attachment is checked based on the containing document as follows:\n"
-        "* Authenticated users are allowed to remove the attachment if they are the owner of the containing document "
-        "or the containing document is owned by an organization and the user has permission to act on behalf "
-        "of that organization.\n\n"
+        "* Authenticated users are allowed to remove the attachment if they are the owner "
+        "of the containing document.\n\n"
+        # TODO: Uncomment when organization features are implemented
+        # "or the containing document is owned by an organization and the user has permission to act on behalf "
+        # "of that organization.\n\n"
         "The following rules apply:\n"
-        "* Attachments of drafts may be removed by the owning user or an organization's representative, "
-        "if the containing document is owned by an organization."
+        "* Attachments of drafts may be removed by the owning user."
+        # TODO: Uncomment when organization features are implemented
+        # "or an organization's representative, "
+        # "if the containing document is owned by an organization."
         "* Attachments may not be removed if the containing document's `lockedAfter` date has passed. "
         "This should be done by removing the whole document.",
         responses={
@@ -216,9 +228,13 @@ attachment_viewset_docs = {
             status.HTTP_403_FORBIDDEN: OpenApiResponse(
                 description="The authenticated user lacks the proper permissions to access the document. "
                 "Depending on the requested document, "
-                "either the user does not belong to the admin group of the service which owns the document, "
-                "the user does not own the document or the user does not have permission to act on behalf "
-                "of the organization which owns the document."
+                "either the user does not belong to the admin group of the service which owns the document "
+                "or the user does not own the document."
+                # TODO: Uncomment when organization features are implemented
+                #   Replace the previous two lines with the following
+                # "either the user does not belong to the admin group of the service which owns the document, "
+                # "the user does not own the document or the user does not have permission to act on behalf "
+                # "of the organization which owns the document."
             ),
             status.HTTP_404_NOT_FOUND: OpenApiResponse(
                 description="No document was found with `documentId` or the document did not have "
@@ -243,11 +259,13 @@ document_viewset_docs = {
         "* Admin users are allowed to fetch all documents which were stored using the service "
         "they are using and whose admins they are.\n"
         "* Authenticated users are allowed to fetch documents which are owned by them and "
-        "which were stored using the service they are using. "
-        "Documents owned by an organization are not returned even if such a document was created by the current user.\n"
-        "* Authenticated users may fetch documents owned by an organization by giving the organization's business ID "
-        "in the search parameters. In this case the user's permission to act on behalf of the organization "
-        "is verified and the results will contain only documents which are owned by the given organization.",
+        "which were stored using the service they are using.",
+        # TODO: Uncomment when organization features are implemented
+        # "Documents owned by an organization are not returned even if such a document
+        # "was created by the current user.\n"
+        # "* Authenticated users may fetch documents owned by an organization by giving the organization's business ID "
+        # "in the search parameters. In this case the user's permission to act on behalf of the organization "
+        # "is verified and the results will contain only documents which are owned by the given organization.",
         parameters=[
             OpenApiParameter(
                 "status",
@@ -263,8 +281,11 @@ document_viewset_docs = {
                 "business_id",
                 OpenApiTypes.STR,
                 description="Search for documents which are owned by the given business ID. "
-                "If this is given, the calling user must either be an admin or have permission to act "
-                "on behalf of the organization",
+                "If this is given, the calling user must either be an admin"
+                # TODO: Uncomment when organization features are implemented
+                #   Replace the previous line with the following
+                # "If this is given, the calling user must either be an admin or have permission to act "
+                # "on behalf of the organization",
             ),
             OpenApiParameter(
                 "user_id",
@@ -286,10 +307,12 @@ document_viewset_docs = {
             ),
             (status.HTTP_400_BAD_REQUEST, "application/json"): _base_400_response(),
             status.HTTP_401_UNAUTHORIZED: _base_401_response(),
-            status.HTTP_403_FORBIDDEN: OpenApiResponse(
-                description="The search parameters contain an organization ID and the currently authenticated user does"
-                "not have permission to act on behalf of that organization."
-            ),
+            # TODO: Uncomment when organization features are implemented
+            # status.HTTP_403_FORBIDDEN: OpenApiResponse(
+            #     description="The search parameters contain an organization ID "
+            #     "and the currently authenticated user does"
+            #     "not have permission to act on behalf of that organization."
+            # ),
             status.HTTP_500_INTERNAL_SERVER_ERROR: _base_500_response(),
         },
         examples=[example_document, example_error],
@@ -300,9 +323,12 @@ document_viewset_docs = {
         "Permission to access the document is checked as follows:\n\n"
         "* Admin users are allowed access to the document if it was stored using the service "
         "they are using and whose admins they are.\n"
-        "* Authenticated users are allowed access to the document if they are the owner of the document "
-        "or the document is owned by an organization and the user has permission to act on behalf "
-        "of that organization.",
+        "* Authenticated users are allowed access to the document if they are the owner of the document.",
+        # TODO: Uncomment when organization features are implemented
+        #   Replace the previous line with the following
+        # "* Authenticated users are allowed access to the document if they are the owner of the document "
+        # "or the document is owned by an organization and the user has permission to act on behalf "
+        # "of that organization.",
         responses={
             (status.HTTP_200_OK, "application/json"): OpenApiResponse(
                 response=DocumentSerializer,
@@ -314,8 +340,10 @@ document_viewset_docs = {
                 description="The authenticated user lacks the proper permissions to access the document. "
                 "Depending on the requested document, "
                 "either the user does not belong to the admin group of the service which owns the document, "
-                "the user does not own the document or the user does not have permission to act on behalf "
-                "of the organization which owns the document."
+                "the user does not own the document."
+                # TODO: Uncomment when organization features are implemented
+                # " or the user does not have permission to act on behalf "
+                # "of the organization which owns the document."
             ),
             status.HTTP_404_NOT_FOUND: OpenApiResponse(
                 description="No document was found with `documentId`.",
@@ -340,10 +368,11 @@ document_viewset_docs = {
             ),
             (status.HTTP_400_BAD_REQUEST, "application/json"): _base_400_response(),
             status.HTTP_401_UNAUTHORIZED: _base_401_response(),
-            status.HTTP_403_FORBIDDEN: OpenApiResponse(
-                description="The request contains an organization ID and the currently authenticated user "
-                "does not have permission to act on behalf of that organization."
-            ),
+            # TODO: Uncomment when organization features are implemented
+            # status.HTTP_403_FORBIDDEN: OpenApiResponse(
+            #     description="The request contains an organization ID and the currently authenticated user "
+            #     "does not have permission to act on behalf of that organization."
+            # ),
             status.HTTP_500_INTERNAL_SERVER_ERROR: _base_500_response(),
         },
         examples=[example_document, example_error],
@@ -353,12 +382,19 @@ document_viewset_docs = {
         description="Permission to access the document is checked as follows:\n\n"
         "* Admin users are allowed access to the document if it was stored using the service they are using "
         "and whose admins they are.\n"
-        "* Authenticated users are allowed access to the document if they are the owner of the document "
-        "or the document is owned by an organization and the user has permission to act "
-        "on behalf of that organization.\n\n"
+        "* Authenticated users are allowed access to the document if they are the owner of the document.\n\n"
+        # TODO: Uncomment when organization features are implemented
+        #   Replace the previous line with the following
+        # "* Authenticated users are allowed access to the document if they are the owner of the document "
+        # "or the document is owned by an organization and the user has permission to act "
+        # "on behalf of that organization.\n\n"
         "The following rules apply:\n"
-        "* Drafts may be modified by the owning user, the owning service's admin or an organization's representative, "
-        "if the document is owned by an organization.\n"
+        "* Drafts may be modified by the owning user or the owning service's admin.\n"
+        # TODO: Uncomment when organization features are implemented
+        #   Replace the previous line with the following
+        # "* Drafts may be modified by the owning user, the owning service's admin "
+        # "or an organization's representative, "
+        # "if the document is owned by an organization.\n"
         "* Non-drafts may be modified by an admin.\n"
         "* Documents may not be modified if their `lockedAfter` date has passed.",
         responses={
@@ -373,8 +409,10 @@ document_viewset_docs = {
                 description="The authenticated user lacks the proper permissions to access the document. "
                 "Depending on the requested document, "
                 "either the user does not belong to the admin group of the service which owns the document, "
-                "the user does not own the document or the user does not have permission to act on behalf "
-                "of the organization which owns the document."
+                "the user does not own the document."
+                # TODO: Uncomment when organization features are implemented
+                # " or the user does not have permission to act on behalf "
+                # "of the organization which owns the document."
             ),
             status.HTTP_404_NOT_FOUND: OpenApiResponse(
                 description="No document was found with `documentId`.",
@@ -386,13 +424,15 @@ document_viewset_docs = {
     "destroy": extend_schema(
         summary="Remove an existing document and its attachments",
         description="Permission to access the document is checked as follows:\n"
-        "* Authenticated users are allowed access to the document if they are the owner of the document "
-        "or the document is owned by an organization and the user has permission to act "
-        "on behalf of that organization.\n\n"
-        "The following rules apply:\n"
-        "* Drafts may be removed by the owning user or an organization's representative, "
-        "if the document is owned by an organization. This is possible even if the `lockedAfter` date has passed, "
-        "to enable a user to remove expired applications.",
+        "* Authenticated users are allowed access to the document if they are the owner of the document.\n\n"
+        # TODO: Uncomment when organization features are implemented
+        # "or the document is owned by an organization and the user has permission to act "
+        # "on behalf of that organization.\n\n"
+        "The following rules apply:\n" "* Drafts may be removed by the owning user.",
+        # TODO: Uncomment when organization features are implemented
+        # "or an organization's representative, "
+        # "if the document is owned by an organization. This is possible even if the `lockedAfter` date has passed, "
+        # "to enable a user to remove expired applications.",
         responses={
             status.HTTP_204_NO_CONTENT: OpenApiResponse(
                 description="The specified Document and its attachments were removed successfully",
@@ -403,8 +443,10 @@ document_viewset_docs = {
                 description="The authenticated user lacks the proper permissions to access the document. "
                 "Depending on the requested document, "
                 "either the user does not belong to the admin group of the service which owns the document, "
-                "the user does not own the document or the user does not have permission to act on behalf "
-                "of the organization which owns the document."
+                "the user does not own the document."
+                # TODO: Uncomment when organization features are implemented
+                # " or the user does not have permission to act on behalf "
+                # "of the organization which owns the document."
             ),
             status.HTTP_404_NOT_FOUND: OpenApiResponse(
                 description="No document was found with `documentId`.",

--- a/documents/api/querysets.py
+++ b/documents/api/querysets.py
@@ -1,0 +1,77 @@
+from django.db.models import QuerySet
+
+from services.enums import ServicePermissions
+from services.models import Service
+from users.models import User
+
+from ..models import Attachment, Document
+
+
+def get_document_queryset(user: User, service: Service) -> QuerySet:
+    """
+    Only allow for the user to see Documents that belong to them or their Service.
+
+    If the user is:
+        - superuser, they can see everything
+        - staff, they can see only Documents for their Service
+        - authenticated, they can see only their own Documents
+        - anonymous (no valid authentication), they can't see anything
+    """
+
+    # If the user is a superuser, return the whole set
+    if user.is_superuser:
+        return Document.objects.all()
+
+    # If the user is anonymous, don't return anything,
+    # even if they're associated to a Service.
+    if user.is_anonymous:
+        return Document.objects.none()
+
+    # Filter the Documents only for the user's Service
+    qs_filters = {"service": service}
+
+    # If the user doesn't have permissions to view that Service,
+    # only show the Documents that belong to them
+    staff_can_view = user.has_perm(ServicePermissions.VIEW_DOCUMENTS.value, service)
+    staff_can_manage = user.has_perm(ServicePermissions.MANAGE_DOCUMENTS.value, service)
+
+    if not staff_can_view and not staff_can_manage:
+        qs_filters["user_id"] = user.id
+
+    return Document.objects.filter(**qs_filters)
+
+
+def get_attachment_queryset(user: User, service: Service) -> QuerySet:
+    """
+    Only allow for the user to see Attachments that belong to their Documents
+    or their Service.
+
+    If the user is:
+        - superuser, they can see everything
+        - staff, they can see only Attachments for Documents of their Service
+        - authenticated, they can see only their own Attachments
+        - anonymous (no valid authentication), they can't see anything
+    """
+    # If the user is a superuser, return the whole set
+    if user.is_superuser:
+        return Attachment.objects.all()
+
+    # If the user is anonymous, don't return anything,
+    # even if they're associated to a Service.
+    if user.is_anonymous:
+        return Attachment.objects.none()
+
+    # Filter the Documents only for the user's Service
+    qs_filters = {"document__service": service}
+
+    # If the user doesn't have permissions to view that Service,
+    # only show the Documents that belong to them
+    staff_can_view = user.has_perm(ServicePermissions.VIEW_ATTACHMENTS.value, service)
+    staff_can_manage = user.has_perm(
+        ServicePermissions.MANAGE_ATTACHMENTS.value, service
+    )
+
+    if not staff_can_view and not staff_can_manage:
+        qs_filters["document__user_id"] = user.id
+
+    return Attachment.objects.filter(**qs_filters)

--- a/documents/api/viewsets.py
+++ b/documents/api/viewsets.py
@@ -18,7 +18,7 @@ from services.enums import ServicePermissions
 from services.utils import get_service_from_request
 
 from ..consts import VALID_OWNER_PATCH_FIELDS
-from ..models import Attachment, Document
+from ..models import Attachment
 from ..serializers import (
     AttachmentSerializer,
     CreateAnonymousDocumentSerializer,
@@ -27,6 +27,7 @@ from ..serializers import (
 )
 from .docs import attachment_viewset_docs, document_viewset_docs
 from .filtersets import DocumentFilterSet
+from .querysets import get_attachment_queryset, get_document_queryset
 
 
 @extend_schema_view(**attachment_viewset_docs)
@@ -37,40 +38,10 @@ class AttachmentViewSet(AuditLoggingModelViewSet, NestedViewSetMixin):
     ordering = ["-updated_at", "id"]
 
     def get_queryset(self):
-        """
-        Only allow for the user to see Attachments that belong to their Documents
-        or their Service.
-
-        If the user is:
-            - superuser, they can see everything
-            - staff, they can see only Attachments for Documents of their Service
-            - authenticated, they can see only their own Attachments
-            - anonymous (no valid authentication), they can't see anything
-        """
         user = self.request.user
-
-        # If the user is a superuser, return the whole set
-        if user.is_superuser:
-            return Attachment.objects.all()
-
-        # If the user is anonymous, don't return anything,
-        # even if they're associated to a Service.
-        if user.is_anonymous:
-            return Attachment.objects.none()
-
         service = get_service_from_request(self.request)
 
-        qs_filters = {}
-
-        # Filter the Documents only for the user's Service
-        qs_filters["document__service"] = service
-
-        # If the user doesn't have permissions to view that Service,
-        # only show the Documents that belong to them
-        if not user.has_perm(ServicePermissions.VIEW_ATTACHMENTS.value, service):
-            qs_filters = {"document__user_id": user.id}
-
-        return Attachment.objects.filter(**qs_filters)
+        return get_attachment_queryset(user, service)
 
     @login_required()
     def retrieve(self, request, pk, *args, **kwargs):
@@ -133,43 +104,10 @@ class DocumentViewSet(AuditLoggingModelViewSet):
     filterset_class = DocumentFilterSet
 
     def get_queryset(self):
-        """
-        Only allow for the user to see Documents that belong to them or their Service.
-
-        If the user is:
-            - superuser, they can see everything
-            - staff, they can see only Documents for their Service
-            - authenticated, they can see only their own Documents
-            - anonymous (no valid authentication), they can't see anything
-        """
         user = self.request.user
-
-        # If the user is a superuser, return the whole set
-        if user.is_superuser:
-            return Document.objects.all()
-
-        # If the user is anonymous, don't return anything,
-        # even if they're associated to a Service.
-        if user.is_anonymous:
-            return Document.objects.none()
-
         service = get_service_from_request(self.request)
 
-        qs_filters = {}
-
-        # Filter the Documents only for the user's Service
-        qs_filters["service"] = service
-
-        # If the user doesn't have permissions to view that Service,
-        # only show the Documents that belong to them
-        staff_can_view = user.has_perm(ServicePermissions.VIEW_DOCUMENTS.value, service)
-        staff_can_manage = user.has_perm(
-            ServicePermissions.MANAGE_DOCUMENTS.value, service
-        )
-        if not staff_can_view and not staff_can_manage:
-            qs_filters["user_id"] = user.id
-
-        return Document.objects.filter(**qs_filters)
+        return get_document_queryset(user, service)
 
     @login_required()
     def retrieve(self, request, *args, **kwargs):

--- a/documents/tests/snapshots/snap_test_api_create_attachment.py
+++ b/documents/tests/snapshots/snap_test_api_create_attachment.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import Snapshot
+
+snapshots = Snapshot()
+
+snapshots["test_create_attachment 1"] = {
+    "created_at": "2021-06-30T12:00:00+03:00",
+    "filename": "document1.pdf",
+    "href": "http://testserver/v1/documents/5209bdd0-e626-4a7d-aa4d-73aaf961a93f/attachments/1/",
+    "media_type": "application/pdf",
+    "size": 12,
+    "updated_at": "2021-06-30T12:00:00+03:00",
+}

--- a/documents/tests/test_api_create_attachment.py
+++ b/documents/tests/test_api_create_attachment.py
@@ -1,0 +1,125 @@
+import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import override_settings
+from freezegun import freeze_time
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+from audit_log.models import AuditLogEntry
+from documents.models import Attachment
+from documents.tests.factories import DocumentFactory
+from services.tests.utils import get_user_service_client
+from utils.exceptions import get_error_response
+
+
+@pytest.fixture
+def document_data():
+    return {
+        "file": SimpleUploadedFile(
+            "document1.pdf",
+            b"file_content",
+            content_type="application/pdf",
+        )
+    }
+
+
+@freeze_time("2021-06-30T12:00:00+03:00")
+def test_create_attachment(user, service, document_data, snapshot):
+    api_client = get_user_service_client(user, service)
+    document = DocumentFactory(
+        id="5209bdd0-e626-4a7d-aa4d-73aaf961a93f",
+        user=user,
+        service=service,
+        draft=True,
+    )
+
+    response = api_client.post(
+        reverse("documents-attachments-list", args=[document.id]),
+        document_data,
+    )
+
+    assert response.status_code == status.HTTP_201_CREATED
+
+    body = response.json()
+    attachment_id = body.pop("id")
+
+    assert document.attachments.count() == 1
+    assert document.attachments.first().id == attachment_id
+
+    snapshot.assert_match(body)
+
+
+@freeze_time("2021-06-30T12:00:00+03:00")
+def test_create_attachment_other_document(user, service):
+    document = DocumentFactory(service=service)
+    api_client = get_user_service_client(user, service)
+
+    response = api_client.post(
+        reverse("documents-attachments-list", args=[document.id]),
+        {},
+    )
+
+    body = response.json()
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert body == get_error_response(
+        "NOT_FOUND",
+        "No Document matches the given query.",
+    )
+
+
+@override_settings(MAX_FILE_SIZE=50)
+def test_create_document_file_limit(user, service, snapshot, settings):
+    api_client = get_user_service_client(user, service)
+    document = DocumentFactory(
+        id="5209bdd0-e626-4a7d-aa4d-73aaf961a93f",
+        user=user,
+        service=service,
+        draft=True,
+    )
+
+    data = {
+        "file": SimpleUploadedFile(
+            "document1.pdf",
+            b"x" * 10000,
+            content_type="application/pdf",
+        )
+    }
+
+    response = api_client.post(
+        reverse("documents-attachments-list", args=[document.id]), data
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert Attachment.objects.count() == 0
+
+    body = response.json()
+    assert body == get_error_response(
+        "MAXIMUM_FILE_SIZE_EXCEEDED",
+        "Cannot upload files larger than 0.0 Mb: 0.01 Mb",
+    )
+
+
+def test_audit_log_is_created_when_creating(user, service, document_data, snapshot):
+    api_client = get_user_service_client(user, service)
+    document = DocumentFactory(
+        id="5209bdd0-e626-4a7d-aa4d-73aaf961a93f",
+        user=user,
+        service=service,
+        draft=True,
+    )
+
+    response = api_client.post(
+        reverse("documents-attachments-list", args=[document.id]),
+        document_data,
+    ).json()
+
+    assert document.attachments.count() == 1
+    assert (
+        AuditLogEntry.objects.filter(
+            message__audit_event__target__type="Attachment",
+            message__audit_event__target__id=str(response["id"]),
+            message__audit_event__operation="CREATE",
+        ).count()
+        == 1
+    )

--- a/documents/tests/test_api_destroy_attachment.py
+++ b/documents/tests/test_api_destroy_attachment.py
@@ -95,7 +95,7 @@ def test_destroy_attachment_owner_non_draft(user, service):
     assert response.status_code == status.HTTP_403_FORBIDDEN
     assert body == get_error_response(
         "DOCUMENT_LOCKED",
-        "Unable to modify document - it's no longer a draft.",
+        "Unable to modify document - it's no longer a draft",
     )
 
 

--- a/documents/tests/test_api_destroy_document.py
+++ b/documents/tests/test_api_destroy_document.py
@@ -78,7 +78,7 @@ def test_destroy_document_owner_non_draft(user, service):
     assert response.status_code == status.HTTP_403_FORBIDDEN
     assert body == get_error_response(
         "DOCUMENT_LOCKED",
-        "Unable to modify document - it's no longer a draft.",
+        "Unable to modify document - it's no longer a draft",
     )
 
 

--- a/documents/tests/test_api_patch_document.py
+++ b/documents/tests/test_api_patch_document.py
@@ -159,7 +159,7 @@ def test_update_document_owner_non_draft(user):
     assert response.status_code == status.HTTP_403_FORBIDDEN
     assert body == get_error_response(
         "DOCUMENT_LOCKED",
-        "Unable to modify document - it's no longer a draft.",
+        "Unable to modify document - it's no longer a draft",
     )
 
 
@@ -183,7 +183,7 @@ def test_update_document_owner_after_lock_date(user):
     assert response.status_code == status.HTTP_403_FORBIDDEN
     assert body == get_error_response(
         "DOCUMENT_LOCKED",
-        "Unable to modify document - it's no longer a draft.",
+        "Unable to modify document - it's no longer a draft",
     )
 
 
@@ -269,7 +269,7 @@ def test_update_document_staff_after_lock_date(user, service):
     assert response.status_code == status.HTTP_403_FORBIDDEN
     assert body == get_error_response(
         "DOCUMENT_LOCKED",
-        "Unable to modify document - it's no longer a draft.",
+        "Unable to modify document - it's no longer a draft",
     )
 
 

--- a/services/utils.py
+++ b/services/utils.py
@@ -53,17 +53,18 @@ def get_service_from_request(
             request, raise_exception=raise_exception
         )
 
-    elif auth := getattr(request, "auth", None):
-        if client_id := auth.data.get("azp"):
-            service_client_id = (
-                ServiceClientId.objects.select_related("service")
-                .filter(client_id=client_id)
-                .first()
-            )
-            if service_client_id:
-                request._service = service_client_id.service
+    if not request.user.is_superuser:
+        if auth := getattr(request, "auth", None):
+            if client_id := auth.data.get("azp"):
+                service_client_id = (
+                    ServiceClientId.objects.select_related("service")
+                    .filter(client_id=client_id)
+                    .first()
+                )
+                if service_client_id:
+                    request._service = service_client_id.service
 
-    if not request._service and raise_exception:
-        raise NotAuthenticated()
+        if not request._service and raise_exception:
+            raise NotAuthenticated()
 
     return request._service


### PR DESCRIPTION
## Description :sparkles:
* Add create method for creating Attachment for Documents
  * Only allowed for the owners of the Document, staff is not allowed

## Issues :bug:
### Closes :no_good_woman:
**[ATV-26](https://helsinkisolutionoffice.atlassian.net/browse/ATV-26):** As an authenticated user I want to add an attachment to my diploma copy request draft to provide a necessary file with the request

## Testing :alembic:
### Automated tests :gear:️
```
$ pytest documents/tests/test_api_create_attachment.py
```

### Manual testing :construction_worker_man:
```
curl --location --request POST 'http://localhost:8000/v1/documents/a9e542d3-35f9-4841-a8f9-22bfd0e15001/attachments/' \
--header 'Authorization: Bearer <YOUR_TOKEN>' \
--header 'Content-Type: image/jpeg' \
--header 'Content-Disposition: attachment; filename="<YOUR_FILENAME>"' \
--data-binary '@/path/to/your/file.jpg'
```

## Screenshots 📸 
<img width="1562" alt="image" src="https://user-images.githubusercontent.com/15201480/134908789-85430b5b-d369-46c8-8fc2-faa769adfbb0.png">


## Additional notes :spiral_notepad:
The file to be uploaded has to be sent as a 