### PR TITLE
ATV-83 | Add user UUID properly to an audit log

### DIFF
--- a/audit_log/admin.py
+++ b/audit_log/admin.py
@@ -6,6 +6,8 @@ from audit_log.models import AuditLogEntry
 @admin.register(AuditLogEntry)
 class AuditLogEntryAdmin(admin.ModelAdmin):
     fields = ("id", "created_at", "message")
+    list_display = ("__str__", "created_at")
+    list_filter = ("created_at", "is_sent")
     readonly_fields = ("id", "created_at", "message")
 
     def has_delete_permission(self, request, obj=None):

--- a/audit_log/audit_logging.py
+++ b/audit_log/audit_logging.py
@@ -41,8 +41,8 @@ def log(
     (a Django model instance), status (e.g. SUCCESS), and a timestamp.
     """
     current_time = get_time()
-    user_id_field_name = getattr(target, "audit_log_id_field", "pk")
-    user_id = str(getattr(actor, user_id_field_name, ""))
+    user_id_field_name = getattr(actor, "audit_log_id_field", "pk")
+    user_id = str(getattr(actor, user_id_field_name, None) or "")
 
     if actor is None:
         role = Role.SYSTEM

--- a/audit_log/tests/snapshots/snap_test_audit_logging.py
+++ b/audit_log/tests/snapshots/snap_test_audit_logging.py
@@ -6,6 +6,24 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
+snapshots["test_log_actor_uuid 1"] = {
+    "audit_event": {
+        "actor": {
+            "ip_address": "192.168.1.1",
+            "provider": "",
+            "role": "USER",
+            "user_id": "7e564b45-527f-4ea6-92c7-3d39ba05733c",
+        },
+        "additional_information": "",
+        "date_time": "2020-06-01T00:00:00.000Z",
+        "date_time_epoch": 1590969600000,
+        "operation": "READ",
+        "origin": "atv",
+        "status": "SUCCESS",
+        "target": {"id": "be584b90-b256-46f5-83e1-4e6a0f8b4cc3", "type": "User"},
+    }
+}
+
 snapshots["test_log_anonymous_role[CREATE] 1"] = {
     "audit_event": {
         "actor": {

--- a/audit_log/tests/test_audit_logging.py
+++ b/audit_log/tests/test_audit_logging.py
@@ -32,6 +32,22 @@ def test_log_current_timestamp(user):
     assert logging_datetime == logged_date_from_date_time
 
 
+def test_log_actor_uuid(fixed_datetime, user, user_factory, snapshot):
+    other_user = user_factory()
+    audit_logging.log(
+        user,
+        "",
+        Operation.READ,
+        other_user,
+        get_time=fixed_datetime,
+        ip_address="192.168.1.1",
+    )
+
+    message = AuditLogEntry.objects.first().message
+    assert message["audit_event"]["actor"]["user_id"] == str(user.uuid)
+    snapshot.assert_match(message)
+
+
 @pytest.mark.parametrize("operation", list(Operation))
 def test_log_owner_operation(fixed_datetime, user, operation, snapshot):
     audit_logging.log(


### PR DESCRIPTION
## Description :sparkles:

Audit log didn't include the user UUID. Audit logging was incorrectly checking from the `target` which field should be used for logging the `actor`.

## Issues :bug:
### Closes :no_good_woman:
**[ATV-83](https://helsinkisolutionoffice.atlassian.net/browse/ATV-83):** Audit log uses actor.pk instead of actor.uuid in message

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

```
$ pytest audit_log/tests/test_audit_logging.py
```

### Manual testing :construction_worker_man:

Access a document from the API as authenticated user and observe that `audit_event.actor.user_id` includes the user UUID.
