### PR TITLE
ATV-82 | Restrict Document's Attachment list

### DIFF
--- a/atv/decorators.py
+++ b/atv/decorators.py
@@ -1,6 +1,6 @@
 from functools import wraps
 
-from rest_framework.exceptions import PermissionDenied
+from rest_framework.exceptions import MethodNotAllowed, PermissionDenied
 
 from services.enums import ServicePermissions
 from services.utils import get_service_from_request, get_service_from_service_key
@@ -62,6 +62,17 @@ def staff_required(required_permission=ServicePermissions.VIEW_DOCUMENTS):
         f"""Decorator that checks for {required_permission} permission."""
 
     return check_permission
+
+
+def not_allowed():
+    def wrapper(function):
+        @wraps(function)
+        def raise_exc(_viewset, request, *args, **kwargs):
+            raise MethodNotAllowed(request.method)
+
+        return raise_exc
+
+    return wrapper
 
 
 def login_required():

--- a/documents/api/viewsets.py
+++ b/documents/api/viewsets.py
@@ -12,7 +12,7 @@ from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework_extensions.mixins import NestedViewSetMixin
 
-from atv.decorators import login_required, service_required
+from atv.decorators import login_required, not_allowed, service_required
 from atv.exceptions import (
     DocumentLockedException,
     InvalidFieldException,
@@ -130,11 +130,13 @@ class AttachmentViewSet(AuditLoggingModelViewSet, NestedViewSetMixin):
             status=status.HTTP_201_CREATED,
         )
 
+    @not_allowed()
     def partial_update(self, request, *args, **kwargs):
-        raise MethodNotAllowed(request.method)
+        pass
 
+    @not_allowed()
     def update(self, request, *args, **kwargs):
-        raise MethodNotAllowed(request.method)
+        pass
 
 
 @extend_schema_view(**document_viewset_docs)

--- a/documents/api/viewsets.py
+++ b/documents/api/viewsets.py
@@ -131,6 +131,10 @@ class AttachmentViewSet(AuditLoggingModelViewSet, NestedViewSetMixin):
         )
 
     @not_allowed()
+    def list(self, request, *args, **kwargs):
+        pass
+
+    @not_allowed()
     def partial_update(self, request, *args, **kwargs):
         pass
 

--- a/documents/tests/test_api_methods_not_allowed.py
+++ b/documents/tests/test_api_methods_not_allowed.py
@@ -1,0 +1,18 @@
+from uuid import uuid4
+
+import pytest
+from django.urls import reverse
+from rest_framework import status
+
+
+@pytest.mark.parametrize(
+    "method,url",
+    [
+        ("PUT", reverse("documents-attachments-detail", args=[uuid4(), uuid4()])),
+        ("PATCH", reverse("documents-attachments-detail", args=[uuid4(), uuid4()])),
+        ("PUT", reverse("documents-detail", args=[uuid4()])),
+    ],
+)
+def test_api_method_not_allowed(method, url, superuser_api_client):
+    response = superuser_api_client.generic(method=method, path=url)
+    assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED

--- a/documents/tests/test_api_methods_not_allowed.py
+++ b/documents/tests/test_api_methods_not_allowed.py
@@ -8,6 +8,7 @@ from rest_framework import status
 @pytest.mark.parametrize(
     "method,url",
     [
+        ("GET", reverse("documents-attachments-list", args=[uuid4()])),
         ("PUT", reverse("documents-attachments-detail", args=[uuid4(), uuid4()])),
         ("PATCH", reverse("documents-attachments-detail", args=[uuid4(), uuid4()])),
         ("PUT", reverse("documents-detail", args=[uuid4()])),


### PR DESCRIPTION
## Description :sparkles:
* Raise a `405 Method Not Allowed` when getting the `documents-attachments-list`
* Add tests for the methods that should raise a 405

## Issues :bug:
### Closes :no_good_woman:
**[ATV-82](https://helsinkisolutionoffice.atlassian.net/browse/ATV-82):** Document's attachments endpoint returns all attachments for user

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest documents/tests/test_api_methods_not_allowed.py
```

### Manual testing :construction_worker_man:
Any random uuid as document ID will work:
```
curl --location --request GET 'http://localhost:9000/v1/documents/b513c411-bd30-45a6-b078-88eb373be442/attachments/' \
--header 'Authorization: Bearer <YOUR_TOKEN>'
```