### PR TITLE
Stop uWSGI logging healhtz and readiness endpoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ EXPOSE 8000/tcp
 USER root
 
 RUN yum --disableplugin subscription-manager -y update \
+    && yum --disableplugin subscription-manager -y install pcre-devel \
     && yum --disableplugin subscription-manager -y clean all
 
 COPY scripts /scripts


### PR DESCRIPTION
## Description :sparkles:

Add internal routing support for uWSGI
- pcre library was missing, which caused the internal
  routing support to not being built into uWSGI

### Manual testing :construction_worker_man:

When using the production image calling `/healthz` or `/readiness` shouldn't produce any logs.
