### PR TITLE
Add default queryset to viewsets to generate proper docs

### DIFF
--- a/documents/api/viewsets.py
+++ b/documents/api/viewsets.py
@@ -24,7 +24,7 @@ from services.utils import get_service_from_request
 from utils.uuid import is_valid_uuid
 
 from ..consts import VALID_OWNER_PATCH_FIELDS
-from ..models import Attachment
+from ..models import Attachment, Document
 from ..serializers import (
     AttachmentSerializer,
     CreateAnonymousDocumentSerializer,
@@ -43,6 +43,7 @@ class AttachmentViewSet(AuditLoggingModelViewSet, NestedViewSetMixin):
     parser_classes = [MultiPartParser, FileUploadParser]
     filter_backends = [filters.OrderingFilter]
     ordering = ["-updated_at", "id"]
+    queryset = Attachment.objects.none()
 
     def get_queryset(self):
         user = self.request.user
@@ -161,6 +162,7 @@ class DocumentViewSet(AuditLoggingModelViewSet):
     ordering = ["-updated_at"]
     search_fields = ["metadata"]
     filterset_class = DocumentFilterSet
+    queryset = Document.objects.none()
 
     def get_queryset(self):
         user = self.request.user


### PR DESCRIPTION
## Description :sparkles:
* Add a default `queryset` value to the `ViewSets` so the documentation can be generated correctly

## Issues :bug:
### Closes :no_good_woman:
**[ATV-84](https://helsinkisolutionoffice.atlassian.net/browse/ATV-84):** API documentation is missing some query filters

## Testing :alembic:
### Manual testing :construction_worker_man:
Open the documentation for `GET documents`, you should see the missing parameters
http://localhost:9000/v1/schema/swagger/#/

## Screenshots :camera_flash:
<img width="603" alt="image" src="https://user-images.githubusercontent.com/15201480/136562907-3a3d74db-4dcf-47c9-bbae-67df5a7d0ced.png">


## Additional notes :spiral_notepad:
The schema generation still throws some warnings that might be nice to address at some point, but they can be ignored for now.
```
Warning #0: DocumentViewSet: could not resolve authenticator <class 'helusers._oidc_auth_impl.ApiTokenAuthentication'>. There was no OpenApiAuthenticationExtension registered for that class. Try creating one by subclassing it. Ignoring for now.
Warning #1: AttachmentViewSet: could not resolve authenticator <class 'helusers._oidc_auth_impl.ApiTokenAuthentication'>. There was no OpenApiAuthenticationExtension registered for that class. Try creating one by subclassing it. Ignoring for now.
Warning #2: SpectacularAPIView: could not resolve authenticator <class 'helusers._oidc_auth_impl.ApiTokenAuthentication'>. There was no OpenApiAuthenticationExtension registered for that class. Try creating one by subclassing it. Ignoring for now.
```