### PR TITLE
Remove deprecated GH action arguments for black

### DIFF
--- a/.github/workflows/py-coding-style.yml
+++ b/.github/workflows/py-coding-style.yml
@@ -14,8 +14,6 @@ jobs:
         uses: actions/checkout@v2
       - name: Run black
         uses: psf/black@stable
-        with:
-          args: ". --check"
 
   flake8:
     name: Coding style - flake8


### PR DESCRIPTION
## Description :sparkles:

This PR removes deprecated arguments from GitHub action for black.
