### PR TITLE
Python shows deprecation warnings when running with docker-compose

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -27,7 +27,7 @@ fi
 if [[ ! -z "$@" ]]; then
     "$@"
 elif [[ "$DEV_SERVER" = "1" ]]; then
-    python ./manage.py runserver 0.0.0.0:8000
+    python -Wd ./manage.py runserver 0.0.0.0:8000
 else
     uwsgi --ini .prod/uwsgi.ini
 fi


### PR DESCRIPTION
## Description :sparkles:

This PR runs python with `-Wd` flag on docker-compose/development.