### PR TITLE
ATV-92 | Allow staff/API key to edit document's content and attachments

### DIFF
--- a/documents/tests/snapshots/snap_test_api_patch_document.py
+++ b/documents/tests/snapshots/snap_test_api_patch_document.py
@@ -30,9 +30,15 @@ snapshots["test_update_document_owner 1"] = {
 }
 
 snapshots["test_update_document_staff 1"] = {
-    "attachments": [],
     "business_id": "1234567-8",
-    "content": "",
+    "content": {
+        "formData": {
+            "birthDate": "3.11.1957",
+            "firstName": "Dolph",
+            "lastName": "Lundgren",
+        },
+        "reasonForApplication": "No reason, just testing",
+    },
     "created_at": "2021-06-30T12:00:00+03:00",
     "draft": True,
     "id": "2d2b7a36-a306-4e35-990f-13aea04263ff",
@@ -49,7 +55,14 @@ snapshots["test_update_document_staff 1"] = {
 snapshots["test_update_document_staff_non_draft 1"] = {
     "attachments": [],
     "business_id": "1234567-8",
-    "content": "",
+    "content": {
+        "formData": {
+            "birthDate": "3.11.1957",
+            "firstName": "Dolph",
+            "lastName": "Lundgren",
+        },
+        "reasonForApplication": "No reason, just testing",
+    },
     "created_at": "2021-06-30T12:00:00+03:00",
     "draft": False,
     "id": "2d2b7a36-a306-4e35-990f-13aea04263ff",


### PR DESCRIPTION
## Description :sparkles:

This PR removes the restrictions for staff users/api-key not being able to update the content or attachments of documents.

## Issues :bug:
### Closes :no_good_woman:
**[ATV-92](https://helsinkisolutionoffice.atlassian.net/browse/ATV-92):**  Allow staff/api-key to edit attachment and content fields
