### PR TITLE
ATV-94 | Staff/API key can create/delete attachments

### DIFF
--- a/documents/api/viewsets.py
+++ b/documents/api/viewsets.py
@@ -62,10 +62,11 @@ class AttachmentViewSet(AuditLoggingModelViewSet, NestedViewSetMixin):
 
         # The user is the owner of the document
         is_owner = request.user == attachment.document.user
+        staff_can_delete = request.user.has_perm(
+            ServicePermissions.DELETE_ATTACHMENTS, attachment.document.service
+        )
 
-        # Only owners are allowed to remove the attachments,
-        # staff users aren't.
-        if not is_owner:
+        if not is_owner and not staff_can_delete:
             raise PermissionDenied()
 
         not_draft = is_owner and not attachment.document.draft
@@ -101,8 +102,11 @@ class AttachmentViewSet(AuditLoggingModelViewSet, NestedViewSetMixin):
 
         # The user is the owner of the document
         is_owner = request.user == document.user
+        staff_can_create = request.user.has_perm(
+            ServicePermissions.ADD_ATTACHMENTS, document.service
+        )
 
-        if not is_owner:
+        if not is_owner and not staff_can_create:
             raise PermissionDenied()
 
         if is_owner and not document.draft:

--- a/documents/tests/snapshots/snap_test_api_create_attachment.py
+++ b/documents/tests/snapshots/snap_test_api_create_attachment.py
@@ -14,3 +14,12 @@ snapshots["test_create_attachment 1"] = {
     "size": 12,
     "updated_at": "2021-06-30T12:00:00+03:00",
 }
+
+snapshots["test_create_attachment_staff[True] 1"] = {
+    "created_at": "2021-06-30T12:00:00+03:00",
+    "filename": "document1.pdf",
+    "href": "http://testserver/v1/documents/5209bdd0-e626-4a7d-aa4d-73aaf961a93f/attachments/2/",
+    "media_type": "application/pdf",
+    "size": 12,
+    "updated_at": "2021-06-30T12:00:00+03:00",
+}

--- a/documents/tests/snapshots/snap_test_api_create_document.py
+++ b/documents/tests/snapshots/snap_test_api_create_document.py
@@ -51,26 +51,3 @@ snapshots["test_create_authenticated_document 1"] = {
     "type": "mysterious form",
     "updated_at": "2021-06-30T12:00:00+03:00",
 }
-
-snapshots["test_create_document 1"] = {
-    "business_id": "1234567-8",
-    "content": {
-        "formData": {
-            "birthDate": "3.11.1957",
-            "firstName": "Dolph",
-            "lastName": "Lundgren",
-        },
-        "reasonForApplication": "No reason, just testing",
-    },
-    "created_at": "2021-06-30T12:00:00+03:00",
-    "draft": False,
-    "locked_after": None,
-    "metadata": {"created_by": "alex", "testing": True},
-    "status": "handled",
-    "tos_function_id": "f917d43aab76420bb2ec53f6684da7f7",
-    "tos_record_id": "89837a682b5d410e861f8f3688154163",
-    "transaction_id": "cf0a341b-6bfd-4f59-8d7c-87bf62ba837b",
-    "type": "mysterious form",
-    "updated_at": "2021-06-30T12:00:00+03:00",
-    "user_id": None,
-}

--- a/documents/tests/test_api_create_document.py
+++ b/documents/tests/test_api_create_document.py
@@ -113,7 +113,7 @@ def test_create_authenticated_document(user, service, snapshot):
 
 
 @freeze_time("2021-06-30T12:00:00+03:00")
-def test_create_anonymous_document_no_service(api_client, snapshot):
+def test_create_anonymous_document_no_service(api_client):
     response = api_client.post(
         reverse("documents-list"), VALID_DOCUMENT_DATA, format="multipart"
     )


### PR DESCRIPTION
## Description :sparkles:

This PR removes the restrictions for staff users/api-key not being able to create or delete attachments of documents.

## Issues :bug:
### Closes :no_good_woman:
**[ATV-94](https://helsinkisolutionoffice.atlassian.net/browse/ATV-94):**  Staff/API-key should be able to create/delete attachments to documents using the attachments endpoint
