### PR TITLE
ATV-77 Document metadata API

### DIFF
--- a/atv/decorators.py
+++ b/atv/decorators.py
@@ -57,7 +57,7 @@ def staff_required(required_permission=ServicePermissions.VIEW_DOCUMENTS):
 
     @_use_request_tests(_require_service_permission(required_permission.value))
     def check_permission():
-        f"""Decorator that checks for {required_permission} permission."""
+        """Decorator that checks for required permission."""
 
     return check_permission
 

--- a/atv/urls.py
+++ b/atv/urls.py
@@ -10,6 +10,7 @@ from drf_spectacular.views import (
 from rest_framework_extensions.routers import ExtendedSimpleRouter
 
 from documents.api import AttachmentViewSet, DocumentViewSet
+from documents.api.viewsets import DocumentMetadataViewSet
 
 router = ExtendedSimpleRouter()
 
@@ -19,6 +20,7 @@ router.register(r"documents", DocumentViewSet, basename="documents").register(
     basename="documents-attachments",
     parents_query_lookups=["document_id"],
 )
+router.register(r"userdocuments", DocumentMetadataViewSet, basename="userdocuments")
 
 
 urlpatterns = [

--- a/documents/api/docs.py
+++ b/documents/api/docs.py
@@ -9,6 +9,7 @@ from drf_spectacular.utils import (
 from rest_framework import serializers, status
 
 from documents.serializers import AttachmentSerializer, DocumentSerializer
+from documents.serializers.document import DocumentMetadataSerializer
 
 error_serializer = inline_serializer(
     "ErrorResponse",
@@ -116,6 +117,27 @@ example_document = OpenApiExample(
                 "href": "https://transactions-storage.com/api/v1/documents/97c0b7a5-0b4c-4470-9a41-48d79454f233/"
                 "attachments/12995",
             },
+        ],
+    },
+)
+
+example_document_metadata = OpenApiExample(
+    name="DocumentExample",
+    response_only=True,
+    status_codes=[str(status.HTTP_200_OK), str(status.HTTP_201_CREATED)],
+    value={
+        "id": "f6fe8acc-3b91-41b3-a176-9d2feab2d2bb",
+        "type": "APPLICATION_FOR_RESIDENTIAL_PARKING_PERMIT",
+        "created_at": "2022-03-07T16:08:39.580394+02:00",
+        "updated_at": "2022-03-07T17:59:39.580394+02:00",
+        "service": "Parking Permits",
+        "status": {
+            "value": "BEING_PROCESSED",
+            "timestamp": "2022-03-07T17:59:39.580394+02:00",
+        },
+        "status_histories": [
+            {"value": "RECEIVED", "timestamp": "2022-03-07T17:48:23.143416+02:00"},
+            {"value": "SENT", "timestamp": "2022-03-07T16:08:39.580394+02:00"},
         ],
     },
 )
@@ -464,4 +486,35 @@ document_viewset_docs = {
     ),
     # Not implementing
     "update": extend_schema(exclude=True),
+}
+
+document_metadata_viewset_docs = {
+    "retrieve": extend_schema(
+        summary="List and filter non sensitive parts of users documents.",
+        description="""List users documents parts that doesn't contain sensitive information to easily see current
+        applications and documents of a single user across services.""",
+        # "of that organization.",
+        responses={
+            (status.HTTP_200_OK, "application/json"): OpenApiResponse(
+                response=DocumentMetadataSerializer,
+                description="User was found and their documents are listed.",
+            ),
+            (status.HTTP_400_BAD_REQUEST, "application/json"): _base_400_response(),
+            status.HTTP_401_UNAUTHORIZED: _base_401_response(),
+            status.HTTP_403_FORBIDDEN: OpenApiResponse(
+                description="Current authentication doesn't allow viewing of this users documents"
+            ),
+            status.HTTP_404_NOT_FOUND: OpenApiResponse(
+                description="No user matches the given query.",
+            ),
+            status.HTTP_500_INTERNAL_SERVER_ERROR: _base_500_response(),
+        },
+        examples=[example_document_metadata, example_error],
+    ),
+    # Not implementing
+    "list": extend_schema(exclude=True),
+    "update": extend_schema(exclude=True),
+    "partial_update": extend_schema(exclude=True),
+    "destroy": extend_schema(exclude=True),
+    "create": extend_schema(exclude=True),
 }

--- a/documents/api/filtersets.py
+++ b/documents/api/filtersets.py
@@ -3,8 +3,7 @@ from django_filters import rest_framework as filters
 from ..models import Document
 
 
-class DocumentFilterSet(filters.FilterSet):
-    user_id = filters.UUIDFilter(field_name="user__uuid")
+class DocumentMetadataFilterSet(filters.FilterSet):
     service_name = filters.CharFilter(
         field_name="service__name", label="Service's name"
     )
@@ -20,6 +19,14 @@ class DocumentFilterSet(filters.FilterSet):
     updated_after = filters.DateFilter(
         field_name="updated_at", lookup_expr="gt", label="Updated after"
     )
+
+    class Meta:
+        model = Document
+        fields = ["status", "type"]
+
+
+class DocumentFilterSet(DocumentMetadataFilterSet):
+    user_id = filters.UUIDFilter(field_name="user__uuid")
 
     class Meta:
         model = Document

--- a/documents/api/viewsets.py
+++ b/documents/api/viewsets.py
@@ -56,7 +56,6 @@ class DocumentMetadataViewSet(AuditLoggingModelViewSet):
     filterset_class = DocumentMetadataFilterSet
 
     def get_queryset(self):
-        super().get_queryset()
         user = self.request.user
         service_api_key = get_service_api_key_from_request(self.request)
         return get_document_metadata_queryset(user, service_api_key)

--- a/documents/serializers/document.py
+++ b/documents/serializers/document.py
@@ -17,6 +17,37 @@ from .attachment import AttachmentSerializer, CreateAttachmentSerializer
 from .status_history import StatusHistorySerializer
 
 
+def status_to_representation(representation):
+    representation["status"] = {
+        "value": representation["status"],
+        "timestamp": representation["created_at"],
+    }
+    return representation
+
+
+class DocumentMetadataSerializer(serializers.HyperlinkedModelSerializer):
+    status_histories = StatusHistorySerializer(many=True, read_only=True)
+    service = serializers.CharField(
+        source="service.name", required=False, read_only=True
+    )
+
+    class Meta:
+        model = Document
+        fields = (
+            "id",
+            "type",
+            "created_at",
+            "updated_at",
+            "service",
+            "status",
+            "status_histories",
+        )
+
+    def to_representation(self, instance):
+        rep = super().to_representation(instance)
+        return status_to_representation(rep)
+
+
 class DocumentSerializer(serializers.ModelSerializer):
     """Basic "read" serializer for the Document model"""
 
@@ -77,11 +108,7 @@ class DocumentSerializer(serializers.ModelSerializer):
 
     def to_representation(self, instance):
         representation = super().to_representation(instance)
-        representation["status"] = {
-            "value": representation["status"],
-            "timestamp": representation["updated_at"],
-        }
-        return representation
+        return status_to_representation(representation)
 
 
 class CreateAnonymousDocumentSerializer(serializers.ModelSerializer):

--- a/documents/serializers/document.py
+++ b/documents/serializers/document.py
@@ -20,7 +20,7 @@ from .status_history import StatusHistorySerializer
 def status_to_representation(representation):
     representation["status"] = {
         "value": representation["status"],
-        "timestamp": representation["created_at"],
+        "timestamp": representation["updated_at"],
     }
     return representation
 

--- a/documents/tests/test_api_retrieve_document.py
+++ b/documents/tests/test_api_retrieve_document.py
@@ -8,7 +8,9 @@ from rest_framework.reverse import reverse
 from atv.tests.factories import GroupFactory
 from documents.tests.factories import DocumentFactory
 from services.enums import ServicePermissions
+from services.tests.factories import ServiceFactory
 from services.tests.utils import get_user_service_client
+from users.tests.factories import UserFactory
 from utils.exceptions import get_error_response
 
 
@@ -97,3 +99,86 @@ def test_list_document_no_permissions(api_client):
         "NOT_AUTHENTICATED",
         "Authentication credentials were not provided.",
     )
+
+
+def test_get_user_document_metadatas_superuser(superuser_api_client):
+    expected_document_id = "485af718-d9d1-46b9-ad7b-33ea054126e3"
+    expected_user_id = "66d0bfd0-308c-484d-aa22-301512899ae3"
+
+    document = DocumentFactory(
+        id=expected_document_id,
+        user__uuid=expected_user_id,
+        tos_function_id="81eee139736f4e52b046a1b27211c202",
+        tos_record_id="0f499febb6414e1dafc93febca5ef312",
+        transaction_id="bd3fd958-cfeb-4ab1-bea4-5c058e8fee5c",
+    )
+
+    response = superuser_api_client.get(
+        reverse("userdocuments-detail", args=[expected_user_id])
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+    assert response.json().get("count") == 1
+
+
+def test_get_user_document_metadatas_service_api_key(user, service_api_client):
+    service = ServiceFactory()
+    other_service = ServiceFactory()
+
+    document = DocumentFactory(
+        id="485af718-d9d1-46b9-ad7b-33ea054126e3",
+        user=user,
+        service=service,
+        tos_function_id="81eee139736f4e52b046a1b27211c202",
+        tos_record_id="0f499febb6414e1dafc93febca5ef312",
+        transaction_id="bd3fd958-cfeb-4ab1-bea4-5c058e8fee5c",
+    )
+    document = DocumentFactory(
+        id="585af718-d9d1-46b9-ad7b-33ea054126e3",
+        user=user,
+        service=other_service,
+        tos_function_id="81eee139736f4e52b046a1b27211c202",
+        tos_record_id="0f499febb6414e1dafc93febca5ef312",
+        transaction_id="bd3fd958-cfeb-4ab1-bea4-5c058e8fee5c",
+    )
+
+    response = service_api_client.get(reverse("userdocuments-detail", args=[user.uuid]))
+    assert response.status_code == status.HTTP_200_OK
+
+    assert response.json().get("count") == 2
+
+
+def test_get_user_document_metadatas_user(user, service):
+    api_client = get_user_service_client(user, service)
+
+    document = DocumentFactory(
+        id="485af718-d9d1-46b9-ad7b-33ea054126e3",
+        user=user,
+        tos_function_id="81eee139736f4e52b046a1b27211c202",
+        tos_record_id="0f499febb6414e1dafc93febca5ef312",
+        transaction_id="bd3fd958-cfeb-4ab1-bea4-5c058e8fee5c",
+    )
+
+    response = api_client.get(reverse("userdocuments-detail", args=[user.uuid]))
+
+    assert response.status_code == status.HTTP_200_OK
+
+    assert response.json().get("count") == 1
+
+
+def test_get_user_document_metadatas_wrong_user(user, service):
+    api_client = get_user_service_client(user, service)
+
+    other_user = UserFactory()
+    document = DocumentFactory(
+        id="485af718-d9d1-46b9-ad7b-33ea054126e3",
+        user=other_user,
+        tos_function_id="81eee139736f4e52b046a1b27211c202",
+        tos_record_id="0f499febb6414e1dafc93febca5ef312",
+        transaction_id="bd3fd958-cfeb-4ab1-bea4-5c058e8fee5c",
+    )
+
+    response = api_client.get(reverse("userdocuments-detail", args=[other_user.uuid]))
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/documents/tests/test_api_retrieve_document.py
+++ b/documents/tests/test_api_retrieve_document.py
@@ -182,3 +182,11 @@ def test_get_user_document_metadatas_wrong_user(user, service):
     response = api_client.get(reverse("userdocuments-detail", args=[other_user.uuid]))
 
     assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_get_user_document_metadatas_user_doesnt_exist(service_api_client):
+    response = service_api_client.get(
+        reverse("userdocuments-detail", args=["bd3fd958-cfeb-4ab1-bea4-5c058e8fee5c"])
+    )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/documents/tests/test_api_retrieve_document.py
+++ b/documents/tests/test_api_retrieve_document.py
@@ -105,7 +105,7 @@ def test_get_user_document_metadatas_superuser(superuser_api_client):
     expected_document_id = "485af718-d9d1-46b9-ad7b-33ea054126e3"
     expected_user_id = "66d0bfd0-308c-484d-aa22-301512899ae3"
 
-    document = DocumentFactory(
+    DocumentFactory(
         id=expected_document_id,
         user__uuid=expected_user_id,
         tos_function_id="81eee139736f4e52b046a1b27211c202",
@@ -126,7 +126,7 @@ def test_get_user_document_metadatas_service_api_key(user, service_api_client):
     service = ServiceFactory()
     other_service = ServiceFactory()
 
-    document = DocumentFactory(
+    DocumentFactory(
         id="485af718-d9d1-46b9-ad7b-33ea054126e3",
         user=user,
         service=service,
@@ -134,7 +134,7 @@ def test_get_user_document_metadatas_service_api_key(user, service_api_client):
         tos_record_id="0f499febb6414e1dafc93febca5ef312",
         transaction_id="bd3fd958-cfeb-4ab1-bea4-5c058e8fee5c",
     )
-    document = DocumentFactory(
+    DocumentFactory(
         id="585af718-d9d1-46b9-ad7b-33ea054126e3",
         user=user,
         service=other_service,
@@ -152,7 +152,7 @@ def test_get_user_document_metadatas_service_api_key(user, service_api_client):
 def test_get_user_document_metadatas_user(user, service):
     api_client = get_user_service_client(user, service)
 
-    document = DocumentFactory(
+    DocumentFactory(
         id="485af718-d9d1-46b9-ad7b-33ea054126e3",
         user=user,
         tos_function_id="81eee139736f4e52b046a1b27211c202",
@@ -171,7 +171,7 @@ def test_get_user_document_metadatas_wrong_user(user, service):
     api_client = get_user_service_client(user, service)
 
     other_user = UserFactory()
-    document = DocumentFactory(
+    DocumentFactory(
         id="485af718-d9d1-46b9-ad7b-33ea054126e3",
         user=other_user,
         tos_function_id="81eee139736f4e52b046a1b27211c202",


### PR DESCRIPTION
API for fetching documents specific to a single user without including sensitive information
Tests for API
Updated docs

## Description :sparkles:
This API allows filtering through documents of a single user throughout all services without revealing sensitive information withing the documents to allow easier collaboration of different services. 

## Issues :bug:
### Closes :no_good_woman:
**[ATV-77](https://helsinkisolutionoffice.atlassian.net/jira/software/c/projects/ATV/boards/207?modal=detail&selectedIssue=ATV-77): As a user I want to view the metadata of my documents in across services** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️
Yes

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
