### PR TITLE
ATV-95 Virus scan incoming files

### DIFF
--- a/atv/exceptions.py
+++ b/atv/exceptions.py
@@ -82,3 +82,9 @@ class MissingParameterException(APIException):
             detail = f"{detail}: {parameter}."
 
         super().__init__(detail=detail, code=code or self.default_code)
+
+
+class MaliciousFileException(APIException):
+    status_code = status.HTTP_400_BAD_REQUEST
+    default_code = "MALICIOUS FILE DETECTED"
+    default_detail = _("Malware detected.")

--- a/atv/settings.py
+++ b/atv/settings.py
@@ -59,6 +59,7 @@ env = environ.Env(
     TOKEN_AUTH_ACCEPTED_SCOPE_PREFIX=(str, ""),
     TOKEN_AUTH_REQUIRE_SCOPE=(bool, False),
     TOKEN_AUTH_AUTHSERVER_URL=(str, ""),
+    CLAMAV_HOST=(str, "atv-clamav"),
 )
 if os.path.exists(env_file):
     env.read_env(env_file)
@@ -266,3 +267,6 @@ LOGGING = {
     },
     "loggers": {"": {"handlers": ["console"], "level": env("DJANGO_LOG_LEVEL")}},
 }
+
+# Malware Protection
+CLAMAV_HOST = env("CLAMAV_HOST")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,13 @@ services:
             ELASTICSEARCH_HOSTS: '["http://atv-elastic:9200"]'
         container_name: atv-kibana
 
+    clamav:
+        image: clamav/clamav:stable
+        hostname: atv-clamav
+        ports:
+            - "3310:3310"
+        container_name: atv-clamav
+
     django:
         build:
             context: .

--- a/documents/serializers/attachment.py
+++ b/documents/serializers/attachment.py
@@ -5,6 +5,7 @@ from atv.exceptions import MaximumFileSizeExceededException
 from utils.files import b_to_mb
 
 from ..models import Attachment
+from ..utils import virus_scan_attachment_file
 
 
 class AttachmentSerializer(serializers.ModelSerializer):
@@ -43,7 +44,10 @@ class CreateAttachmentSerializer(serializers.ModelSerializer):
 
     def validate(self, attrs):
         """Validate that the uploaded files are smaller than settings.MAX_FILE_SIZE."""
-        if (size := attrs.get("file").size) > settings.MAX_FILE_SIZE:
+        file = attrs.get("file")
+        if (size := file.size) > settings.MAX_FILE_SIZE:
             raise MaximumFileSizeExceededException(file_size=b_to_mb(size))
-
+        data = file.read()
+        file.seek(0)
+        virus_scan_attachment_file(data)
         return attrs

--- a/documents/tests/test_api_create_attachment.py
+++ b/documents/tests/test_api_create_attachment.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import override_settings
@@ -39,10 +41,13 @@ def test_create_attachment(user, service, document_data, snapshot):
         service=service,
         draft=True,
     )
+    with mock.patch(
+        "documents.serializers.attachment.virus_scan_attachment_file", return_value=None
+    ):
 
-    response = api_client.post(
-        reverse("documents-attachments-list", args=[document.id]), document_data
-    )
+        response = api_client.post(
+            reverse("documents-attachments-list", args=[document.id]), document_data
+        )
 
     assert response.status_code == status.HTTP_201_CREATED
 
@@ -164,10 +169,12 @@ def test_create_attachment_staff(
         service=service,
         draft=True,
     )
-
-    response = api_client.post(
-        reverse("documents-attachments-list", args=[document.id]), document_data
-    )
+    with mock.patch(
+        "documents.serializers.attachment.virus_scan_attachment_file", return_value=None
+    ):
+        response = api_client.post(
+            reverse("documents-attachments-list", args=[document.id]), document_data
+        )
 
     if has_permission:
         assert response.status_code == status.HTTP_201_CREATED
@@ -197,10 +204,12 @@ def test_audit_log_is_created_when_creating(user, service, document_data, snapsh
         service=service,
         draft=True,
     )
-
-    response = api_client.post(
-        reverse("documents-attachments-list", args=[document.id]), document_data
-    ).json()
+    with mock.patch(
+        "documents.serializers.attachment.virus_scan_attachment_file", return_value=None
+    ):
+        response = api_client.post(
+            reverse("documents-attachments-list", args=[document.id]), document_data
+        ).json()
 
     assert document.attachments.count() == 1
     assert (

--- a/documents/tests/test_api_create_document.py
+++ b/documents/tests/test_api_create_document.py
@@ -1,5 +1,6 @@
 import json
 import uuid
+from unittest import mock
 
 import pytest
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -48,10 +49,12 @@ def test_create_anonymous_document(service_api_client, snapshot):
             ),
         ],
     }
-
-    response = service_api_client.post(
-        reverse("documents-list"), data, format="multipart"
-    )
+    with mock.patch(
+        "documents.serializers.attachment.virus_scan_attachment_file", return_value=None
+    ):
+        response = service_api_client.post(
+            reverse("documents-list"), data, format="multipart"
+        )
 
     assert response.status_code == status.HTTP_201_CREATED
     assert Document.objects.count() == 1
@@ -238,10 +241,12 @@ def test_audit_log_is_created_when_creating(service_api_client, attachments):
             )
             for i in range(attachments)
         ]
-
-    response = service_api_client.post(
-        reverse("documents-list"), data, format="multipart"
-    ).json()
+    with mock.patch(
+        "documents.serializers.attachment.virus_scan_attachment_file", return_value=None
+    ):
+        response = service_api_client.post(
+            reverse("documents-list"), data, format="multipart"
+        ).json()
 
     assert Document.objects.count() == 1
 

--- a/documents/tests/test_api_patch_document.py
+++ b/documents/tests/test_api_patch_document.py
@@ -1,4 +1,5 @@
 import json
+from unittest import mock
 from uuid import uuid4
 
 import pytest
@@ -64,10 +65,12 @@ def test_update_document_owner(user, snapshot):
             ),
         ],
     }
-
-    response = api_client.patch(
-        reverse("documents-detail", args=[document.id]), data, format="multipart"
-    )
+    with mock.patch(
+        "documents.serializers.attachment.virus_scan_attachment_file", return_value=None
+    ):
+        response = api_client.patch(
+            reverse("documents-detail", args=[document.id]), data, format="multipart"
+        )
 
     assert Document.objects.count() == 1
     assert document.attachments.count() == 1
@@ -213,10 +216,12 @@ def test_update_document_staff(user, service, snapshot):
             ),
         ],
     }
-
-    response = api_client.patch(
-        reverse("documents-detail", args=[document.id]), data, format="multipart"
-    )
+    with mock.patch(
+        "documents.serializers.attachment.virus_scan_attachment_file", return_value=None
+    ):
+        response = api_client.patch(
+            reverse("documents-detail", args=[document.id]), data, format="multipart"
+        )
 
     assert Document.objects.count() == 1
     assert document.attachments.count() == 1
@@ -455,8 +460,10 @@ def test_audit_log_is_created_when_patching(user, attachments):
             )
             for i in range(attachments)
         ]
-
-    api_client.patch(reverse("documents-detail", args=[document.id]), data)
+    with mock.patch(
+        "documents.serializers.attachment.virus_scan_attachment_file", return_value=None
+    ):
+        api_client.patch(reverse("documents-detail", args=[document.id]), data)
 
     assert (
         AuditLogEntry.objects.filter(

--- a/documents/utils.py
+++ b/documents/utils.py
@@ -1,4 +1,7 @@
 from django.conf import settings
+from pyclamd import pyclamd
+
+from atv.exceptions import MaliciousFileException
 
 
 def get_attachment_file_path(instance, filename):
@@ -12,3 +15,12 @@ def get_document_attachment_directory_path(instance):
     :type instance: documents.models.Document
     """
     return f"{settings.ATTACHMENT_MEDIA_DIR}/{instance.id}/"
+
+
+# TODO: Consider scanning files on download as well to improve chance of catching most recent threats to protect users
+#   if clamav virus databases didn't include the virus' profile at the time of upload
+# Note this function is mocked in testing because there is no clamav connection during pipeline testing
+def virus_scan_attachment_file(file_data):
+    cd = pyclamd.ClamdNetworkSocket(host=settings.CLAMAV_HOST)
+    if cd.scan_stream(file_data) is not None:
+        raise MaliciousFileException

--- a/requirements.in
+++ b/requirements.in
@@ -13,3 +13,4 @@ drf-spectacular
 psycopg2
 sentry_sdk
 elasticsearch
+pyclamd

--- a/requirements.txt
+++ b/requirements.txt
@@ -76,6 +76,8 @@ pyasn1==0.4.8
     # via
     #   python-jose
     #   rsa
+pyclamd==0.4.0
+    # via -r requirements.in
 pycryptodome==3.11.0
     # via django-searchable-encrypted-fields
 pycryptodomex==3.11.0


### PR DESCRIPTION
Add error response for detected malware
Add clamav config to docker-compose.yml
Add clamav host settings
Fix failing tests when running tests without clamav connection

## Description :sparkles:
Support for clamav virus scanning within the cluster

## Issues :bug:
### Closes :no_good_woman:
**[ATV-95](https://helsinkisolutionoffice.atlassian.net/browse/ATV-95):Virus scan incoming files**

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️
Edited tests to mock clamav scan

### Manual testing :construction_worker_man:
Manually tested scanner response to malware (EICAR test file)

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
Running without docker in dev environment requires installing clamav locally