### PR TITLE
ATV-116 Fix Dockerfile to prevent pipeline build failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ EXPOSE 8000/tcp
 
 USER root
 
-RUN yum --disableplugin subscription-manager -y update \
+RUN yum --disableplugin subscription-manager -y --allowerasing update \
     && yum --disableplugin subscription-manager -y install pcre-devel \
     && yum --disableplugin subscription-manager -y clean all
 


### PR DESCRIPTION
Add --allowerasing argument to update to fix incompatible packages

## Description :sparkles:

## Issues :bug:
### Closes :no_good_woman:
**[ATV-116](https://helsinkisolutionoffice.atlassian.net/browse/ATV-116): Fix dockerfile to prevent pipeline build failure** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:
Tested build process in local environment after reproducing bug
## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
