### PR TITLE
ATV-125 Add transaction_id as a filterable field to userdocuments end…

### DIFF
--- a/documents/api/docs.py
+++ b/documents/api/docs.py
@@ -537,6 +537,23 @@ document_metadata_viewset_docs = {
             status.HTTP_500_INTERNAL_SERVER_ERROR: _base_500_response(),
         },
         examples=[example_document_metadata, example_error],
+        parameters=[
+            OpenApiParameter(
+                "status",
+                OpenApiTypes.STR,
+                description="Search for documents with the given status",
+            ),
+            OpenApiParameter(
+                "type",
+                OpenApiTypes.STR,
+                description="Search for documents with the given type",
+            ),
+            OpenApiParameter(
+                "transaction_id",
+                OpenApiTypes.STR,
+                description="Search for documents with the given transaction id",
+            ),
+        ],
     ),
     # Not implementing
     "list": extend_schema(exclude=True),

--- a/documents/api/filtersets.py
+++ b/documents/api/filtersets.py
@@ -74,7 +74,7 @@ class DocumentMetadataFilterSet(filters.FilterSet):
 
     class Meta:
         model = Document
-        fields = ["status", "type"]
+        fields = ["status", "type", "transaction_id"]
 
 
 class DocumentFilterSet(DocumentMetadataFilterSet):

--- a/documents/api/querysets.py
+++ b/documents/api/querysets.py
@@ -27,6 +27,7 @@ def get_document_metadata_queryset(
             "type",
             "human_readable_type",
             "user__id",
+            "transaction_id",
         )
         .select_related("service", "user")
         .prefetch_related("status_histories")

--- a/documents/tests/test_api_retrieve_document.py
+++ b/documents/tests/test_api_retrieve_document.py
@@ -199,3 +199,31 @@ def test_get_user_document_metadatas_anonymous_user(api_client):
     )
 
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_user_document_metadatas_filtering_user(user, service):
+    api_client = get_user_service_client(user, service)
+    transaction_id = "bd3fd958-cfeb-4ab1-bea4-5c058e8fee5c"
+    DocumentFactory(
+        id="485af718-d9d1-46b9-ad7b-33ea054126e3",
+        user=user,
+        tos_function_id="81eee139736f4e52b046a1b27211c202",
+        tos_record_id="0f499febb6414e1dafc93febca5ef312",
+        transaction_id=transaction_id,
+    )
+    DocumentFactory(
+        id="485af718-d9d1-46b9-ad7b-33ea054126e4",
+        user=user,
+        tos_function_id="81eee139736f4e52b046a1b27211c202",
+        tos_record_id="0f499febb6414e1dafc93febca5ef312",
+        transaction_id="bd3fd958-cfeb-4ab1-bea4-5c058e8fee5f",
+    )
+
+    response = api_client.get(
+        reverse("userdocuments-detail", args=[user.uuid])
+        + f"?transaction_id={transaction_id}"
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+    assert response.json().get("count") == 1


### PR DESCRIPTION
…point

Allow filtering with transaction_id
Note: transaction_id is not included in response
Update api documentation
Add test for filtering

## Description :sparkles:

## Issues :bug:
### Closes :no_good_woman:
**[ATV-125](https://helsinkisolutionoffice.atlassian.net/browse/ATV-125): Add transaction_id as filterable field to userdocuments endpoint** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️
Yes
### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
