### PR TITLE
ATV-134 Fix GDPR API delete response status

### DIFF
--- a/documents/api/docs.py
+++ b/documents/api/docs.py
@@ -601,6 +601,8 @@ document_metadata_viewset_docs = {
 document_gdpr_viewset = {
     "retrieve": extend_schema(
         examples=[example_gdpr_api_repsonse],
+        description="Used to fetch GDPR data of an user from single service.",
+        summary="List user's document details and number of deletable and undeletable documents.",
         responses={
             (status.HTTP_200_OK, "application/json"): OpenApiResponse(
                 response=GDPRSerializer,
@@ -619,8 +621,10 @@ document_gdpr_viewset = {
     ),
     "destroy": extend_schema(
         examples=[example_gdpr_api_repsonse],
+        description="Delete user's documents from a single service that aren't under contractual obligation.",
+        summary="List user's documents that weren't deleted. Deletable field should be zero.",
         responses={
-            (status.HTTP_204_NO_CONTENT, "application/json"): OpenApiResponse(
+            (status.HTTP_200_OK, "application/json"): OpenApiResponse(
                 response=GDPRSerializer,
                 description="User was found and their deletable documents and attachments have been removed. "
                 "Documents with contractual oblications are returned in response body."
@@ -632,9 +636,6 @@ document_gdpr_viewset = {
             ),
             status.HTTP_403_FORBIDDEN: OpenApiResponse(
                 description="Current authentication doesn't allow viewing of this users documents"
-            ),
-            status.HTTP_404_NOT_FOUND: OpenApiResponse(
-                description="No user matches the given query.",
             ),
             status.HTTP_500_INTERNAL_SERVER_ERROR: _base_500_response(),
         },

--- a/documents/api/viewsets.py
+++ b/documents/api/viewsets.py
@@ -77,12 +77,7 @@ class GDPRDataViewSet(AuditLoggingModelViewSet):
         with self.record_action():
             queryset = self.filter_queryset(self.get_queryset()).filter(**kwargs)
             serializer = self.get_serializer(queryset)
-            return Response(
-                serializer.data,
-                status=status.HTTP_204_NO_CONTENT
-                if request.method == "DELETE"
-                else status.HTTP_200_OK,
-            )
+            return Response(serializer.data)
 
     def destroy(self, request, *args, **kwargs):
         with self.record_action():
@@ -93,6 +88,7 @@ class GDPRDataViewSet(AuditLoggingModelViewSet):
                 )
                 Attachment.objects.filter(document__in=qs).delete()
                 qs.update(user=None, content={}, business_id="")
+            # Return details on documents that weren't deleted
             return self.retrieve(request, **kwargs)
 
     @not_allowed()

--- a/documents/tests/test_api_destroy_document.py
+++ b/documents/tests/test_api_destroy_document.py
@@ -264,7 +264,7 @@ def test_gdpr_delete_user_data_service_user(user, service_api_client):
     assert body["data"]["total_undeletable"] == 1
 
     response = service_api_client.delete(reverse("gdpr-api-detail", args=[user.uuid]))
-    assert response.status_code == status.HTTP_204_NO_CONTENT
+    assert response.status_code == status.HTTP_200_OK
 
     body = response.data
     assert body["data"]["total_deletable"] == 0


### PR DESCRIPTION
Change delete response status to HTTP 200 from 204 due to response having a body Fix and Improve documentation
Fix test

## Description :sparkles:
Bug fix
## Issues :bug:
### Closes :no_good_woman:
**[ATV-134](https://helsinkisolutionoffice.atlassian.net/browse/ATV-134): Fix GDPR API delete response status code** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️
Yes
### Manual testing :construction_worker_man:
Yes
## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
