### PR TITLE
ATV-169 Add sentry debugging url

### DIFF
--- a/atv/settings.py
+++ b/atv/settings.py
@@ -36,6 +36,7 @@ env = environ.Env(
     CACHE_URL=(str, "locmemcache://"),
     SENTRY_DSN=(str, ""),
     SENTRY_ENVIRONMENT=(str, "development"),
+    SENTRY_DEBUG=(bool, False),
     CORS_ORIGIN_WHITELIST=(list, []),
     CORS_ORIGIN_ALLOW_ALL=(bool, False),
     CORS_ALLOW_HEADERS=(list, []),
@@ -83,6 +84,7 @@ sentry_sdk.init(
     integrations=[DjangoIntegration()],
     before_send=sentry_before_send,
 )
+SENTRY_DEBUG = env("SENTRY_DEBUG")
 
 BASE_DIR = str(checkout_dir)
 

--- a/atv/urls.py
+++ b/atv/urls.py
@@ -43,6 +43,11 @@ urlpatterns = [
     path("v1/", include(router.urls)),
 ]
 
+if settings.SENTRY_DEBUG:
+    urlpatterns += [
+        path("sentry-debug/", lambda a: 1 / 0),
+    ]
+
 
 if settings.ENABLE_SWAGGER_UI:
     urlpatterns += [

--- a/documents/api/docs.py
+++ b/documents/api/docs.py
@@ -151,6 +151,7 @@ example_document = OpenApiExample(
         "draft": True,
         "locked_after": "2021-08-01T00:00:00.0Z",
         "deletable": False,
+        "delete_after": "2030-12-12",
         "document_language": "fi",
         "content_schema_url": "https://exampleurl.fi",
         "content": {
@@ -307,6 +308,7 @@ example_gdpr_api_repsonse = OpenApiExample(
                     "type": "mysterious form",
                     "human_readable_type": {"en": "Mysterious Form"},
                     "deletable": True,
+                    "delete_after": "2030-12-12",
                     "attachment_count": 0,
                     "attachments": [],
                 },
@@ -318,6 +320,7 @@ example_gdpr_api_repsonse = OpenApiExample(
                     "type": "mysterious form",
                     "human_readable_type": {},
                     "deletable": False,
+                    "delete_after": "2030-12-12",
                     "attachment_count": 1,
                     "attachments": ["myfavoritesong.mp3"],
                 },
@@ -841,8 +844,10 @@ document_statistics_viewset_docs = {
                 description="Request was allowed and documents were listed",
             ),
             (status.HTTP_400_BAD_REQUEST, "application/json"): _base_400_response(),
-            status.HTTP_401_UNAUTHORIZED: "Request's credentials are missing or invalid. An API-key is required, or an "
-            "user token associated with statistics service.",
+            status.HTTP_401_UNAUTHORIZED: OpenApiResponse(
+                "Request's credentials are missing or invalid. An API-key is required, or an "
+                "user token associated with statistics service.",
+            ),
             status.HTTP_403_FORBIDDEN: OpenApiResponse(
                 description="Current authentication doesn't allow viewing document statistics"
             ),

--- a/documents/api/viewsets.py
+++ b/documents/api/viewsets.py
@@ -169,6 +169,8 @@ class DocumentStatisticsViewSet(AuditLoggingModelViewSet):
 
     def get_queryset(self):
         user = self.request.user
+        if user.is_anonymous:
+            raise NotAuthenticated
         if not get_service_api_key_from_request(self.request) and not user.has_perm(
             "users.view_document_statistics"
         ):


### PR DESCRIPTION
Add sentry-debug url which always causes an error that is sent to sentry Add setting and environment variable for sentry debugging

Minor fixes
Fix statistics api incorrect 403 when not authenticated Fix missing fields in api docs

## Description :sparkles:

## Issues :bug:
### Closes :no_good_woman:
**[ATV-169](https://helsinkisolutionoffice.atlassian.net/browse/ATV-169): Add url for sentry debugging** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️
No
### Manual testing :construction_worker_man:
Yes
## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[ATV-169]: https://helsinkisolutionoffice.atlassian.net/browse/ATV-169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ