### PR TITLE
ATV-174 Update lookfor filter to use iexact instead of icontains

### DIFF
--- a/documents/api/docs.py
+++ b/documents/api/docs.py
@@ -573,7 +573,7 @@ document_viewset_docs = {
                 OpenApiTypes.STR,
                 description="Search for documents with metadata matching key:value pairs separated by comma."
                 " ( key:value, key:value )."
-                " Lookup method for value is 'contains', key must be exact and is case sensitive.",
+                " Lookup method for value is 'iexact', key must be exact and is case sensitive.",
             ),
         ],
         responses={

--- a/documents/api/filtersets.py
+++ b/documents/api/filtersets.py
@@ -41,7 +41,7 @@ class MetadataJSONFilter(Filter):
             try:
                 key, value = part.split(":", maxsplit=1)
                 qs = qs.filter(
-                    metadata__has_key=key, **{"metadata__" + key + "__icontains": value}
+                    metadata__has_key=key, **{"metadata__" + key + "__iexact": value}
                 )
             except ValueError:
                 raise ValidationError(


### PR DESCRIPTION
Sometimes icontains returns irrelevant results due to words containing each other

## Description :sparkles:
make metadata filtering exact
## Issues :bug:
### Closes :no_good_woman:
**[ATV-174](https://helsinkisolutionoffice.atlassian.net/browse/ATV-174): Change lookfor filter to use iexact instead of icontains** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:
Yes
## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[ATV-174]: https://helsinkisolutionoffice.atlassian.net/browse/ATV-174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ