### PR TITLE
ATV-176 Document batch list

### DIFF
--- a/documents/api/docs.py
+++ b/documents/api/docs.py
@@ -630,6 +630,37 @@ document_viewset_docs = {
         },
         examples=[example_document, example_error],
     ),
+    "batch_list": extend_schema(
+        summary="Fetch multiple documents by IDs",
+        description="This endpoint allows a service to fetch multiple documents by their IDs",
+        # TODO: Uncomment when organization features are implemented
+        #   Replace the previous line with the following
+        # "* Authenticated users are allowed access to the document if they are the owner of the document "
+        # "or the document is owned by an organization and the user has permission to act on behalf "
+        # "of that organization.",
+        request=serializers.JSONField(),
+        responses={
+            (status.HTTP_200_OK, "application/json"): OpenApiResponse(
+                response=DocumentSerializer,
+                description="The document/s was found and contents are returned as JSON.",
+            ),
+            (status.HTTP_400_BAD_REQUEST, "application/json"): _base_400_response(),
+            status.HTTP_401_UNAUTHORIZED: _base_401_response(),
+            status.HTTP_403_FORBIDDEN: OpenApiResponse(
+                description="The authenticated user lacks the proper permissions to access the document. "
+                "Depending on the requested document, "
+                "either the user does not belong to the admin group of the service which owns the document, "
+                "the user does not own the document."
+                # TODO: Uncomment when organization features are implemented
+                # " or the user does not have permission to act on behalf "
+                # "of the organization which owns the document."
+            ),
+            status.HTTP_404_NOT_FOUND: OpenApiResponse(
+                description="No document was found with `documentId`.",
+            ),
+            status.HTTP_500_INTERNAL_SERVER_ERROR: _base_500_response(),
+        },
+    ),
     "create": extend_schema(
         summary="Store a new document and its attachments",
         description="Store a new document and its attachments.\n\n"

--- a/documents/tests/snapshots/snap_test_api_patch_document.py
+++ b/documents/tests/snapshots/snap_test_api_patch_document.py
@@ -25,7 +25,7 @@ snapshots["test_update_document_owner 1"] = {
     "id": "2d2b7a36-a306-4e35-990f-13aea04263ff",
     "locked_after": None,
     "metadata": {"created_by": "alex", "testing": True},
-    "service": "service 155",
+    "service": "service 160",
     "status": {
         "timestamp": "2021-06-30T12:00:00+03:00",
         "value": "handled",
@@ -59,7 +59,7 @@ snapshots["test_update_document_staff 1"] = {
     "id": "2d2b7a36-a306-4e35-990f-13aea04263ff",
     "locked_after": None,
     "metadata": {"created_by": "alex", "testing": True},
-    "service": "service 161",
+    "service": "service 166",
     "status": {
         "timestamp": "2021-06-30T12:00:00+03:00",
         "value": "handled",
@@ -94,7 +94,7 @@ snapshots["test_update_document_staff_non_draft 1"] = {
     "id": "2d2b7a36-a306-4e35-990f-13aea04263ff",
     "locked_after": None,
     "metadata": {"created_by": "alex", "testing": True},
-    "service": "service 163",
+    "service": "service 168",
     "status": {
         "timestamp": "2021-06-30T12:00:00+03:00",
         "value": "handled",

--- a/documents/tests/snapshots/snap_test_api_retrieve_document.py
+++ b/documents/tests/snapshots/snap_test_api_retrieve_document.py
@@ -19,7 +19,7 @@ snapshots["test_list_document_service_user 1"] = {
     "id": "485af718-d9d1-46b9-ad7b-33ea054126e3",
     "locked_after": None,
     "metadata": {},
-    "service": "service 207",
+    "service": "service 212",
     "status": {
         "timestamp": "2020-06-01T03:00:00+03:00",
         "value": "testing",
@@ -47,7 +47,7 @@ snapshots["test_list_document_superuser 1"] = {
     "id": "485af718-d9d1-46b9-ad7b-33ea054126e3",
     "locked_after": None,
     "metadata": {},
-    "service": "service 210",
+    "service": "service 215",
     "status": {
         "timestamp": "2020-06-01T03:00:00+03:00",
         "value": "testing",
@@ -75,7 +75,7 @@ snapshots["test_retrieve_document_owner 1"] = {
     "id": "485af718-d9d1-46b9-ad7b-33ea054126e3",
     "locked_after": None,
     "metadata": {},
-    "service": "service 209",
+    "service": "service 214",
     "status": {
         "timestamp": "2020-06-01T03:00:00+03:00",
         "value": "testing",


### PR DESCRIPTION
Add endpoint for fetching multiple documents per id Add tests for endpoint
Update test snapshots
Update docs

## Description :sparkles:
Allows fetching multiple specified documents at once.
## Issues :bug:
### Closes :no_good_woman:
**[ATV-176](https://helsinkisolutionoffice.atlassian.net/browse/ATV-176): Document batch list** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️
Yes

### Manual testing :construction_worker_man:
Yes
## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
Swagger docs are incomplete

[ATV-176]: https://helsinkisolutionoffice.atlassian.net/browse/ATV-176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ