### PR TITLE
ATV-179 Fix Attachment deletion with permission

### DIFF
--- a/documents/api/viewsets.py
+++ b/documents/api/viewsets.py
@@ -356,7 +356,9 @@ class AttachmentViewSet(AuditLoggingModelViewSet, NestedViewSetMixin):
                 # Only pass the locked date if it's after the date
                 locked_after=attachment.document.locked_after if is_locked else None
             )
-        if not attachment.document.deletable:
+        if not (
+            attachment.document.deletable or attachment.document.draft
+        ) and not request.user.has_perm("users.delete_document_undeletable"):
             raise PermissionDenied(
                 "File can't be deleted due to contractual obligation."
             )


### PR DESCRIPTION
Add permission check to allow deletion of attachment with special permission

Updated test case

## Description :sparkles:
User with assigned permission should be able to delete both any document or attachment from their service.
## Issues :bug:
### Closes :no_good_woman:
**[ATV-179](https://helsinkisolutionoffice.atlassian.net/browse/ATV-179): Can't delete undeletable attachment with special permission** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️
Yes
### Manual testing :construction_worker_man:
Yes
## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[ATV-179]: https://helsinkisolutionoffice.atlassian.net/browse/ATV-179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ