### PR TITLE
ATV-178 Update Django and Black versions

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ attrs==23.2.0
     # via
     #   -c requirements.txt
     #   flake8-bugbear
-black==24.1.1
+black==24.3.0
     # via -r requirements-dev.in
 cfgv==3.4.0
     # via pre-commit

--- a/requirements.in
+++ b/requirements.in
@@ -11,7 +11,7 @@ drf-extensions
 drf-oidc-auth==0.10.0
 drf-spectacular
 psycopg2
-sentry_sdk
+sentry_sdk==1.24.0
 elasticsearch==7.15.2
 pyclamd
 jsonschema

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ charset-normalizer==3.3.2
     # via requests
 deprecation==2.1.0
     # via django-helusers
-django==4.2.9
+django==4.2.11
     # via
     #   -r requirements.in
     #   django-cors-headers


### PR DESCRIPTION
Lock sentry version to 1.24.0

## Description :sparkles:
Update vulnerable dependencies

## Issues :bug:
### Closes :no_good_woman:
**[ATV-178](https://helsinkisolutionoffice.atlassian.net/browse/ATV-178): Update dependencies** 

### Related :handshake:

## Testing :alembic:
### Automated tests :gear:️

### Manual testing :construction_worker_man:
Yes
## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[ATV-178]: https://helsinkisolutionoffice.atlassian.net/browse/ATV-178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ