### PR TITLE
Remove metadata on GDPR delete

### DIFF
--- a/documents/api/viewsets.py
+++ b/documents/api/viewsets.py
@@ -234,7 +234,7 @@ class GDPRDataViewSet(AuditLoggingModelViewSet):
                     deletable=True, **kwargs
                 )
                 Attachment.objects.filter(document__in=qs).delete()
-                qs.update(user=None, content={}, business_id="")
+                qs.update(user=None, content={}, business_id="", metadata={})
             # Return details on documents that weren't deleted
             queryset = self.filter_queryset(self.get_queryset()).filter(**kwargs)
             serializer = self.get_serializer(queryset)

--- a/documents/models.py
+++ b/documents/models.py
@@ -192,7 +192,6 @@ class Document(UUIDModel, TimestampedModel):
     metadata = models.JSONField(
         default=dict,
         blank=True,
-        # null=True,  # TODO should we allow null?
         encoder=DjangoJSONEncoder,
         verbose_name=_("metadata"),
         help_text=_(

--- a/documents/tests/test_api_destroy_document.py
+++ b/documents/tests/test_api_destroy_document.py
@@ -308,11 +308,12 @@ def test_gdpr_delete_user_data_service_user(user, service_api_client):
     # Documents are anonymized
     assert Document.objects.count() == 3
     for document in Document.objects.filter(deletable=True).values(
-        "content", "business_id", "user_id"
+        "content", "business_id", "user_id", "metadata"
     ):
         assert document["content"] == {}
         assert document["business_id"] == ""
         assert document["user_id"] is None
+        assert document["metadata"] == {}
 
     assert Attachment.objects.count() == 1
 


### PR DESCRIPTION
## Description :sparkles:

Remove metadata from documents when performing ~GPDR~ GDPR delete.

## Issues :bug:
### Closes :no_good_woman:
**[ATV-213](https://helsinkisolutionoffice.atlassian.net/browse/ATV-213)**

## Testing :alembic:
### Automated tests :gear:️

Add an assert to an existing test.


[ATV-213]: https://helsinkisolutionoffice.atlassian.net/browse/ATV-213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ